### PR TITLE
Update requirements.txt

### DIFF
--- a/llmware/requirements.txt
+++ b/llmware/requirements.txt
@@ -18,7 +18,7 @@ scipy==1.11.2
 sentence-transformers==2.2.2
 tabulate==0.9.0
 tokenizers==0.15.0
-torch==1.13.1
+torch>=1.16.0
 transformers==4.35.2
 Werkzeug==3.0.1
 word2number==1.1


### PR DESCRIPTION
The current requirements do not build.   The cause an error is below:

75.31 ERROR: Cannot install -r /llmware/llmware/requirements.txt (line 18), sentence-transformers and torch==1.13.1 because these package versions have conflicting dependencies. 75.31 
75.31 The conflict is caused by:
75.31     The user requested torch==1.13.1
75.31     sentence-transformers 2.2.2 depends on torch>=1.6.0
75.31     torchvision 0.16.1 depends on torch==2.1.1
75.31     The user requested torch==1.13.1
75.31     sentence-transformers 2.2.2 depends on torch>=1.6.0
75.31     torchvision 0.16.0 depends on torch==2.1.0
75.31     The user requested torch==1.13.1
75.31     sentence-transformers 2.2.2 depends on torch>=1.6.0
75.31     torchvision 0.15.2 depends on torch==2.0.1
75.31     The user requested torch==1.13.1
75.31     sentence-transformers 2.2.2 depends on torch>=1.6.0
75.31     torchvision 0.15.1 depends on torch==2.0.0
75.31 
75.31 To fix this you could try to:
75.31 1. loosen the range of package versions you've specified
75.31 2. remove package versions to allow pip attempt to solve the dependency conflict
75.31 
75.31 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
75.34 
75.34 [notice] A new release of pip is available: 23.2.1 -> 23.3.1
75.34 [notice] To update, run: pip install --upgrade pip
------