### PR TITLE
Dual pass check mandatory keys

### DIFF
--- a/llmware/retrieval.py
+++ b/llmware/retrieval.py
@@ -730,6 +730,12 @@ class Query:
                             "safety_check to False in the method declaration, or (2) keep sample count below 100.")
             result_count = 100
 
+        # following keys are required for dual pass query to work
+        keys_to_check = ['_id', 'doc_ID']
+        for key in keys_to_check:
+            if key not in self.query_result_return_keys:
+                self.query_result_return_keys.append(key)
+
         # run dual pass - text + semantic
         # Choose appropriate text query method based on custom_filter
         if custom_filter:

--- a/llmware/retrieval.py
+++ b/llmware/retrieval.py
@@ -730,7 +730,7 @@ class Query:
                             "safety_check to False in the method declaration, or (2) keep sample count below 100.")
             result_count = 100
 
-        # following keys are required for dual pass query to work
+        # following keys are required for dual pass query to work, add them if user has omitted them
         keys_to_check = ['_id', 'doc_ID']
         for key in keys_to_check:
             if key not in self.query_result_return_keys:


### PR DESCRIPTION
if user has ommitted '_id' or  'doc_ID' in keys to return in query by setting query_result_return_keys attribute in Query class, then the dual pass query fails as dual pass uses them while matching results from text and semantic queries and providing final output