### PR TITLE
Fix OCR chunking into single letter chunks for text short text  #293

### DIFF
--- a/llmware/util.py
+++ b/llmware/util.py
@@ -1379,7 +1379,7 @@ class TextChunker:
                 if len(self.chunks) > 0:
                     self.chunks[-1] += chunk
                 else:
-                    self.chunks += chunk
+                    self.chunks.append(chunk)
 
             else:
                 # general case - create next chunk


### PR DESCRIPTION
in TextChunker.convert_text_to_chunks, the updated statement is chunking text into individual characters for short texts, causing explosion of chunks
