### PR TITLE
With this we try to overcome a limitation in mongodb. 

### DIFF
--- a/llmware/resources.py
+++ b/llmware/resources.py
@@ -705,8 +705,17 @@ class MongoRetrieval:
     def get_distinct_list(self, key):
 
         """Returns distinct list of items by key"""
+        # not using distinct operation
+        # distinct can break due to the number of entries in the library
+        # to prevent this from happen we use a aggregate which does not produce a document but a cursor
+        # we loop the cursor and so we overcome the distinct operation 16mb document cap
 
-        distinct_list = list(self.collection.distinct(key))
+        group = self.collection.aggregate([{ "$group": {"_id": f'${key}',}}])
+
+        distinct_list = []
+        for entry in group:
+            distinct_list.append(entry['_id'])
+
         return distinct_list
 
     def filter_by_key_dict (self, key_dict):


### PR DESCRIPTION
mongodb documents are limited to 16mb. any direct result produced by mongo is considered a document and so it is limited to 16mb. this is also true for the result of a collection.distinct() operation. if there is enough documents in the mongo the result can get larger then 16mb and it will break the ingestion process. to overcome that limitation we use now a aggregate operation, that will not produce a document but a cursor and so we can retrieve a unlimited number of data from mongo. this way the number of documents that can be processed during embedding gets from a real big number to a unlimited number. limiting factors are now the available memory and time to process and the time left until the sun gets a red giant and eats our beloved earth :)