### PR TITLE
Reduce loops in input ingestion comparison

### DIFF
--- a/llmware/parsers.py
+++ b/llmware/parsers.py
@@ -2347,6 +2347,9 @@ class Parser:
         for i, file in enumerate(doc_fn_raw_list):
             if file.split(os.sep)[-1] in file_list:
                 found_list.append(file.split(os.sep)[-1])
+            # if found_list is equal length of file_list we don't need to look any further
+            if len(found_list) == len(file_list):
+                break
 
         not_found_list = list(set(file_list) - set(found_list))
 

--- a/llmware/parsers.py
+++ b/llmware/parsers.py
@@ -2323,6 +2323,10 @@ class Parser:
 
     def input_ingestion_comparison (self, file_list):
 
+        # shortcut if file_list is just empty
+        if len(file_list) < 1:
+            return [],[]
+
         """ Compares input with parsed output to identify any rejected files. """
 
         # simple approach - compares input file_list from ingestion 'work_order' with state of library collection
@@ -2335,26 +2339,16 @@ class Parser:
             return -1
 
         found_list = []
-        not_found_list = []
 
         doc_fn_raw_list = CollectionRetrieval(self.library_name,
                                               account_name=self.account_name).get_distinct_list("file_source")
 
-        doc_fn_out = []
+
         for i, file in enumerate(doc_fn_raw_list):
-            doc_fn_out.append(file.split(os.sep)[-1])
+            if file.split(os.sep)[-1] in file_list:
+                found_list.append(file.split(os.sep)[-1])
 
-        for i, input_file in enumerate(file_list):
-            found_file = -1
-            for j, ingested_file in enumerate(doc_fn_out):
-
-                # need to confirm 'symmetrical' transformations, e.g., secure_filename and any prepend/postpend
-                if input_file == ingested_file:
-                    found_file = 1
-                    found_list.append(input_file)
-                    break
-            if found_file == -1:
-                not_found_list.append(input_file)
+        not_found_list = list(set(file_list) - set(found_list))
 
         return found_list, not_found_list
 

--- a/llmware/resources.py
+++ b/llmware/resources.py
@@ -705,8 +705,17 @@ class MongoRetrieval:
     def get_distinct_list(self, key):
 
         """Returns distinct list of items by key"""
+        # not using distinct operation
+        # distinct can break due to the number of entries in the library
+        # to prevent this from happen we use a aggregate which does not produce a document but a cursor
+        # we loop the cursor and so we overcome the distinct operation 16mb document cap
 
-        distinct_list = list(self.collection.distinct(key))
+        group = self.collection.aggregate([{ "$group": {"_id": f'${key}',}}])
+
+        distinct_list = []
+        for entry in group:
+            distinct_list.append(entry['_id'])
+
         return distinct_list
 
     def filter_by_key_dict (self, key_dict):


### PR DESCRIPTION
Here we change the flow a little to get rid of really large loops. 
In the original there is 3 loops
1 loop the distinct result from the store to create a array with only file names and no path
2 loop is file_list times the 3 loop
3 loop is distinct_files times 

in my case it became 
1 loop 700000 times
2 loop 5000 times 
3 loop 700000 times 
so the combination of loop 2 and 3
is a larger loop of 5000*700000 = 3.500.000.000 
thats 3.5 billion.....

what I did is in loop 1 I already reduce the output to just the data needed for this iteration which is such files that are in the store and in file_list

then there is no loop 2 and no loop 3 as now I just substract the found_list from the file_list and that will give us not_found_list

this is a big win in computation time.

additionaly I added a shortcut at the beginning so that if file_list is just empty we do nothing and return empty arrays as that would be the result anyways

My guess is the same would also work for input_ingestion_comparison_from_parser_state
but since I could not test that one as I have no usecase yet I did leave it untouched, But if someone sees this and knows the bigger picture have a look if it could work there the same way