### PR TITLE
fix tokenize whitespace issue (Issue #453)

### DIFF
--- a/llmware/util.py
+++ b/llmware/util.py
@@ -795,9 +795,15 @@ class CorpTokenizer:
         self.one_letter_removal = one_letter_removal
 
     def tokenize(self, text):
+        
+        # strip the whitespace from the beginning and end of the text so we can tokenize the data
+        text = text.strip()
+        # start with basic whitespace tokenizing, 
+        #is there a reason the text is being split on one space only?   
+        #text2 = text.split(" ")
+        # this line will split on whitespace regardless of tab or multispaces between words
+        text2 = text.split()
 
-        # start with basic whitespace tokenizing
-        text2 = text.split(" ")
 
         if self.remove_punctuation:
             text2 = Utilities().clean_list(text2)


### PR DESCRIPTION
array out of bounds error in retrieval #453
fix the tokenize util to strip out front and back whitespace and use any whitespace instead of a single whitespace so we do not have errors in tokenization.