### PR TITLE
QdrantConfig get_config should have name=None

### DIFF
--- a/docker-compose-qdrant.yaml
+++ b/docker-compose-qdrant.yaml
@@ -1,0 +1,22 @@
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    restart: always
+    container_name: qdrant
+    ports:
+      - 6333:6333
+      - 6334:6334
+    expose:
+      - 6333
+      - 6334
+      - 6335
+    configs:
+      - source: qdrant_config
+        target: /qdrant/config/production.yaml
+    volumes:
+      - qdrant_data:/qdrant_data
+
+configs:
+  qdrant_config:
+    content: |
+      log_level: INFO

--- a/examples/Embedding/using_qdrant.py
+++ b/examples/Embedding/using_qdrant.py
@@ -4,7 +4,7 @@
 """ (A) Python Dependencies - 
 
     As a first step, you should pip install dependencies not included in the llmware package:
-        -- pip3 install qdrant
+        -- pip3 install qdrant-client
     
     (B) Installing Qdrant - 
         -- Docker - https://qdrant.tech/documentation/guides/installation/

--- a/llmware/configs.py
+++ b/llmware/configs.py
@@ -579,7 +579,7 @@ class QdrantConfig:
     }
 
     @classmethod
-    def get_config(cls, name):
+    def get_config(cls, name=None):
         if not name:
             return cls._conf
 


### PR DESCRIPTION
name should have a default value if not used in the call, the following if not name: suggests that the idea was to be able to call it with no name as parameter. so I made it def get_config(cls, name=None):