### PR TITLE
Fix broken CI of pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,11 +8,11 @@ name: Documentation
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths: ["docs/**"] # only changes in the docs directory triger the workflow
 
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
     types: ["closed"]
     paths: ["docs/**"]
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,6 +70,10 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR fixes the broken CI of pages by adding the correct name of the branch and adding permission to the deploy job.