### PR TITLE
Fix broken Pinecone implementation

### DIFF
--- a/llmware/configs.py
+++ b/llmware/configs.py
@@ -477,8 +477,11 @@ class PineconeConfig:
 
     """Configuration object for Pinecone"""
 
-    _conf = {"pincone_api_key": os.environ.get("USER_MANAGED_PINECONE_API_KEY"),
-             "pinecone_environment": os.environ.get("USER_MANAGED_PINECONE_ENVIRONMENT")}
+    _conf = {
+        "pinecone_api_key": os.environ.get("USER_MANAGED_PINECONE_API_KEY"),
+        "pinecone_cloud": os.environ.get("USER_MANAGED_PINECONE_CLOUD"),
+        "pinecone_region": os.environ.get("USER_MANAGED_PINECONE_REGION")
+    }
 
     @classmethod
     def get_config(cls, name):


### PR DESCRIPTION
This PR fixes the broken Pinecone implementation.

The source of the issue is likely that while the ``setup.py`` requires ``pinecone-client==3.0.0``, as evident by
https://github.com/llmware-ai/llmware/blob/3e4a9fb2387d5c0ee2982480fadee4a58e4c3870/setup.py#L83
the code itself does not conform to the Pinecone API version 3 - instead, it is on version 2.

This PR fixes this issue by updating the code to the Pinecone API version 3.