### PR TITLE
added a function to the parser called parse_delimiter_config

### DIFF
--- a/llmware/parsers.py
+++ b/llmware/parsers.py
@@ -3114,11 +3114,13 @@ class Parser:
         # will iterate through csv file
         input_file = os.path.join(fp, fn)
 
+        # here we go around using csv.reader() to allow for any delimiter of any length
+        # this helps in cases where a single char delimiter might not be possible due to the content to be spit
+        # is already using any possible character
+        output = []
+
         f = open(input_file, 'r', encoding='utf-8-sig',errors='ignore')
         filedata = f.readlines()
-
-
-        output = []
         for line in filedata:
             output.append(line.split(delimiter))
         f.close()
@@ -3211,6 +3213,7 @@ class Parser:
         output = {"rows_added": added_row_count, "rejected_count": len(rejected_rows), "rejected_rows": rejected_rows}
 
         return output
+
     def parse_csv_config(self,fp, fn, cols=None, mapping_dict=None, delimiter=","):
 
         """ Designed for intake of a 'pseudo-db csv table' and will add rows to library with mapped keys.

--- a/llmware/parsers.py
+++ b/llmware/parsers.py
@@ -3085,6 +3085,9 @@ class Parser:
             -- all other keys will be saved as 'metadata' and added to the library block row in "special_field1"
 
         Note: this feature is currently only supported for Mongo - SQL DB support will follow.
+
+        Sample how to use:
+            parse_delimiter_config(self,fp, fn, cols=None, mapping_dict=None, delimiter="##superspacer##"):
         """
 
         # method requires library loaded in the Parser


### PR DESCRIPTION
it does the exact same thing as parse_csv_config
except it does allow for any possible delimiter to be used as in ##superspecialdelimiter## instead of single character delimiters that sometimes hard to find if the data is complex and unforeseeable