### PR TITLE
Improve about the project section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ ModelCatalog().tool_test_run("slim-sentiment-tool")
 `llmware` is &copy; 2023-{{ "now" | date: "%Y" }} by [AI Bloks](https://www.aibloks.com/home).
 
 ## Contributing
-Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion on GitHub](https://github.com/llmware-ai/llmware/discussions).
+Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
 You can also write an email or start a discussion on our Discrod channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,11 @@ ModelCatalog().tool_test_run("slim-sentiment-tool")
 
 `llmware` is &copy; 2023-{{ "now" | date: "%Y" }} by [AI Bloks](https://www.aibloks.com/home).
 
+## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
+``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home).
+[AI Bloks](https://www.aibloks.com/home) is the company behind ``llmware``, which offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service with the same name.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+
 ## License
 
 `llmware` is distributed by an [Apache-2.0 license](https://github.com/llmware-ai/llmware/blob/main/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,8 +124,8 @@ We welcome everyone into the ``llmware`` community.
 [View our Code of Conduct](https://github.com/llmware-ai/llmware/blob/main/CODE_OF_CONDUCT.md) in our GitHub repository.
 
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
-``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home).
-[AI Bloks](https://www.aibloks.com/home) is the company behind ``llmware``, which offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service with the same name.
+``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
+The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
 [AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,10 @@ Please first discuss any change you want to make publicly, for example on GitHub
 You can also write an email or start a discussion on our Discrod channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
+## Code of conduct
+We welcome everyone into the ``llmware`` community.
+[View our Code of Conduct](https://github.com/llmware-ai/llmware/blob/main/CODE_OF_CONDUCT.md) in our GitHub repository.
+
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home).
 [AI Bloks](https://www.aibloks.com/home) is the company behind ``llmware``, which offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service with the same name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,11 @@ ModelCatalog().tool_test_run("slim-sentiment-tool")
 
 `llmware` is &copy; 2023-{{ "now" | date: "%Y" }} by [AI Bloks](https://www.aibloks.com/home).
 
+## Contributing
+Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion on GitHub](https://github.com/llmware-ai/llmware/discussions).
+You can also write an email or start a discussion on our Discrod channel.
+Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
+
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home).
 [AI Bloks](https://www.aibloks.com/home) is the company behind ``llmware``, which offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service with the same name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,3 +117,14 @@ ModelCatalog().tool_test_run("slim-sentiment-tool")
 ## License
 
 `llmware` is distributed by an [Apache-2.0 license](https://github.com/llmware-ai/llmware/blob/main/LICENSE).
+
+## Thank you to the contributors of ``llmware``!
+<ul class="list-style-none">
+{% for contributor in site.github.contributors %}
+  <li class="d-inline-block mr-1">
+     <a href="{{ contributor.html_url }}">
+        <img src="{{ contributor.avatar_url }}" width="32" height="32" alt="{{ contributor.login }}">
+    </a>
+  </li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
This PR improves the ``About the Project`` section in the docs.

In particular, it adds for subsection, which are
1. A subsection on how to contribute to the project,
2. A subsection on the code of conduct,
3. A subsection on the relationship between ``llmware`` and ``AI Bloks``, and finally
4. A subsection that thanks and lists all the contributors.