### PR TITLE
Fix contributors section in docs

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,7 +6,6 @@ source 'https://rubygems.org'
 #
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 gem "just-the-docs", "0.7.0" # pinned to the current release
-gem 'jekyll-github-metadata', ">= 2.15"
 
 #
 # Gems that are only loaded if they are configured correctly.
@@ -19,3 +18,4 @@ gem 'jekyll-default-layout'
 #
 gem 'jekyll-seo-tag', group: :jekyll_plugins
 gem 'jekyll-include-cache', group: :jekyll_plugins
+gem 'jekyll-github-metadata', ">= 2.15", group: :jekyll_plugins

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,13 +6,12 @@ source 'https://rubygems.org'
 #
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 gem "just-the-docs", "0.7.0" # pinned to the current release
-
+gem 'jekyll-github-metadata', ">= 2.15"
 
 #
 # Gems that are only loaded if they are configured correctly.
 #
 gem 'jekyll-default-layout'
-gem 'jekyll-github-metadata'
 
 
 #

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -79,9 +79,10 @@ GEM
     rouge (4.1.3)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.67.0-arm64-darwin)
+    sass-embedded (1.69.5)
       google-protobuf (~> 3.23)
-    sass-embedded (1.67.0-x86_64-linux-gnu)
+      rake (>= 13.0.0)
+    sass-embedded (1.69.5-arm64-darwin)
       google-protobuf (~> 3.23)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -98,10 +99,10 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3.2)
   jekyll-default-layout
-  jekyll-github-metadata
+  jekyll-github-metadata (>= 2.15)
   jekyll-include-cache
   jekyll-seo-tag
   just-the-docs (= 0.7.0)
 
 BUNDLED WITH
-   2.3.26
+   2.5.6

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,6 +9,7 @@ theme: just-the-docs
 url: https://llmware-ai.github.io/llmware/
 baseurl: "" # the subpath of your site
 favicon_ico: "/assets/images/favicon.ico"
+repository: llmware-ai/llmware # for github-metadata
 
 # Enable or disable heading anchors
 heading_anchors: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ theme: just-the-docs
 url: https://llmware-ai.github.io/llmware/
 baseurl: "" # the subpath of your site
 favicon_ico: "/assets/images/favicon.ico"
-repository: MacOS/llmware # for github-metadata
+repository: llmware-ai/llmware # for github-metadata
 
 # Enable or disable heading anchors
 heading_anchors: true


### PR DESCRIPTION
This PR fixes the broken *contributors section* on the homepage of the docs.

The contributors section was broken as I did not list the contributors. Apparently, the issue was that the plugin was not loaded, and that the variable `repository` was missing.