### PR TITLE
Pin rexml to fix security issue

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 #
 gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
 gem "just-the-docs", "0.7.0" # pinned to the current release
+gem "rexml", "3.2.8" # pinned to that version to fix security alert
 
 #
 # Gems that are only loaded if they are configured correctly.

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -75,17 +75,20 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rouge (4.1.3)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.5-arm64-darwin)
+    sass-embedded (1.69.5)
       google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-x86_64-linux-gnu)
+      rake (>= 13.0.0)
+    sass-embedded (1.69.5-arm64-darwin)
       google-protobuf (~> 3.23)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
@@ -102,6 +105,7 @@ DEPENDENCIES
   jekyll-include-cache
   jekyll-seo-tag
   just-the-docs (= 0.7.0)
+  rexml (= 3.2.8)
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
This PR pins rexml to ```3.2.8``` to fix a security issue from an earlier version.