### PR TITLE
Documentation

### DIFF
--- a/docs/community/troubleshooting.md
+++ b/docs/community/troubleshooting.md
@@ -87,6 +87,15 @@ If you have any trouble, feel free to raise an Issue and we can provide you with
     -- usually the issue will be related to the retrieval step and formation of the Prompt, and as always, good pipelines and a little experimentation usually help !  
 
 
+8. **Newly added examples not working as intended**
+
+    -- If you run a recently added example and it does not run as intended, it is possible that the feature being used in the example has not yet been added to the latest pip install.
+
+    -- To fix this, move the example file to the outer-most directory of the repository, so that the example file you are trying to run is in the same directory as the `llmware` source code directory.
+
+    -- This will let you run the example using the latest source code!
+
+
 # More information about the project - [see main repository](https://www.github.com/llmware-ai/llmware.git)
 
 

--- a/docs/getting_started/working_with_docker.md
+++ b/docs/getting_started/working_with_docker.md
@@ -6,9 +6,95 @@ nav_order: 6
 permalink: /getting_started/working_with_docker
 ---
 
-## Working with Docker Scripts 
+# Working with Docker Scripts 
 
-COMING SOON ...
+This section is a short guide on setting up a Linux environment with Docker and running LLMWare examples with different database systems.
+
+## 1. Python and Pip
+Python should come installed with your Linux environment.
+
+To install Pip, run the following:
+```
+sudo apt-get update
+sudo apt-get -y install python3-pip
+pip3 install --upgrade pip
+```
+
+## 2. Docker and Docker Compose
+The latest versions of Docker and Docker Comopse should be installed to be able to use the Docker Compose files in the LLMWare repository.
+
+Instructions to install Docker: https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-20-04 (Steps 1-2)
+Note: Step 1 is necessary, Step 2 is optional but we highly recommend it.
+
+Instructions to install Docker Compose: https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04 (Step 1)
+Note: replace the URL in the `curl` command with the latest download from https://github.com/docker/compose/releases.
+
+Check that Docker is running on your system:
+```
+sudo systemctl status docker
+```
+
+## 3. Running Docker Compose files
+`cd` into the repository and ensure that you can see files of the format `docker-compose-database-name.yaml`.
+
+To run a Compose file:
+```
+docker-compose -f docker-compose-database-name.yaml up -d
+```
+
+Check that the container is running:
+```
+docker ps
+```
+Note: this will list only the the containers that are currently running, add the `-a` flag (`docker ps -a`) to list all containers (even those that are stopped).
+
+## 4. Test with Examples
+The Compose files currently support 6 database systems:
+- Mongo
+- Postgres/PG Vector
+- Neo4j
+- Milvus
+- Qdrant
+- Redis
+
+Note: PG Vector is an alias for Postgres and is used for vector embeddings.
+
+1. Mongo and Postgres are used as the active database to store library text collections.
+2. PG Vector, Neo4j, Milvus, Qdrant and Redis are used as the vector database to store vector embeddings.
+
+To test that the containers are working as intended, you can modify an example provided in the LLMWare repository. The simplest example to do this is `fast_start/example-2-build_embeddings.py`.
+
+Open the file in an editor.
+1. Change the argument passed in as the active database on line 128 to an appropriate active database (Mongo or Postgres).
+2. Change the argument passed in as the vector database on line 138 to an appropriate vector database (PG Vector, Neo4j, Milvus, Qdrant or Redis).
+
+Run the example with these changes, and you should see updates in the terminal indicating that the embeddings are being generated correctly.
+
+Note: It is possible that you will see an error:
+```
+llmware.exceptions.EmbeddingModelNotFoundException: Embedding model for 'example2_library' could not be located
+```
+In this case, use a unique name for the library name passed in on line 147.
+
+## 5. Stopping/Deleting Containers
+To stop a container, run:
+```
+docker stop container_ID_OR_container_name
+```
+
+To delete a container, run:
+```
+docker rm container_ID_OR_container_name
+```
+
+Note: passing in either the ID or the name will work.
+
+To find the ID or name of a container, run:
+```
+docker ps -a
+```
+
+---
 
 # More information about the project - [see main repository](https://www.github.com/llmware-ai/llmware.git)
 


### PR DESCRIPTION
1. Added a point to the troubleshooting doc about an issue with newer examples, where the example file must be placed in the outer-most directory with the `llmware` source code directory so that the program uses the latest source code and not the source code in `site-packages`.
2. Added instructions for setting up Docker and Docker Compose in `working-with-docker.md`.