### PR TITLE
Two examples using slim topics tool

### DIFF
--- a/examples/SLIM-Agents/document_unique_topics_extraction.py
+++ b/examples/SLIM-Agents/document_unique_topics_extraction.py
@@ -1,0 +1,61 @@
+
+"""
+This example illustrates parsing a document and extracting unique topics using the SLIM topics tool 
+"""
+
+from llmware.parsers import Parser
+from llmware.agents import LLMfx
+from llmware.setup import Setup
+
+
+
+def document_parser():
+    # Add the path to the directory in fp, add the filename in fn
+    fp = "#Add/Path/To/Document"
+    fn = "Filename for analysis.pdf"
+
+
+    #Given the filename and filepath, parses pdf into chunks
+    doc_chunks = Parser().parse_one_pdf(fp,fn)
+    print ("number of chunks: ", len(doc_chunks))
+    #   create a LLMfx object
+    agent = LLMfx()
+    #load in the chunked document. to make the demo run faster or to test, slice it with [0:5]
+    agent.load_work(doc_chunks)
+    #load in the topic tool 
+    agent.load_tool_list(["topics"])
+    
+    funcall_list = []
+    while True:
+        funcall_list.append(agent.exec_multitool_function_call(["topics"]))
+
+        if not agent.increment_work_iteration():
+            break
+        
+    return funcall_list
+#Function to collapse the report to show unique topics
+
+
+def collapser(report):
+    no_duplicates = []
+    #raise this to make your program more selective, lower it to get more topics
+    required_confidence_score = 0.1
+    for entry in report:
+        if entry[0]['confidence_score'] > required_confidence_score:
+            if 'topics' not in entry[0]['llm_response']:
+                continue
+            for topics in entry[0]['llm_response']['topics']:
+                if topics not in no_duplicates:
+                    no_duplicates.append(topics)
+    return no_duplicates
+        
+
+if __name__ == "__main__":
+    analysis = document_parser()
+    print("\n Analysis: Shows Topics located in each chunk of the Document \n")
+    print(analysis)
+    print("\n Collapsed Analysis: Shows Unique topics located over the entire Document that meet the required confidence score. \n")
+    print(collapser(analysis))
+
+
+

--- a/examples/SLIM-Agents/youtube_topics_extraction.py
+++ b/examples/SLIM-Agents/youtube_topics_extraction.py
@@ -1,0 +1,71 @@
+"""
+This script demonstrates how to extract topics from a youtube video transcript using the LLMfx agent and the slim topics tool. 
+Transcripts are obtained by video ID through the youtube_transcript_api, saved to a text file, and then parsed by the LLMfx agent.
+"""
+
+from llmware.parsers import Parser
+from llmware.agents import LLMfx
+from llmware.setup import Setup
+import os
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api.formatters import TextFormatter
+
+
+
+def transcript_parser(file_dest, file_name):
+    # Given the filename and filepath, parses pdf into chunks
+    
+    doc_chunks = Parser().parse_one_text(file_dest, file_name)
+    print("number of chunks: ", len(doc_chunks))
+    
+    # Create a LLMfx object
+    agent = LLMfx()
+    # Load in the chunked document. To make the demo run faster or to test, slice it with [0:5]
+    agent.load_work(doc_chunks)
+    # Load in the topic tool
+    agent.load_tool_list(["topics"])
+    
+    funcall_list = []
+    while True:
+        funcall_list.append(agent.exec_multitool_function_call(["topics"]))
+
+        if not agent.increment_work_iteration():
+            break
+        
+    return funcall_list
+
+# Function to collapse the report to show unique topics
+def collapser(report):
+    no_duplicates = []
+    # Raise this to make your program more selective, lower it to get more topics
+    required_confidence_score = 0.1
+    for entry in report:
+        if entry[0]['confidence_score'] > required_confidence_score:
+            if 'topics' not in entry[0]['llm_response']:
+                continue
+            for topics in entry[0]['llm_response']['topics']:
+                if topics not in no_duplicates:
+                    no_duplicates.append(topics)
+    return no_duplicates
+
+if __name__ == "__main__":
+    #Edit the Video ID to the desired video
+    video_id = "a62ghRjnLFU"
+    formatter = TextFormatter()
+    transcript = YouTubeTranscriptApi.get_transcript(video_id)
+    text_formatted = formatter.format_transcript(transcript)
+
+# Save the formatted text to a file
+    file_name = "transcript.txt"
+    file_dest = os.getcwd()
+    file_path = os.path.join(file_dest, file_name)
+    print("Transcript saved to: ", file_path)
+    with open(file_path, "w") as file:
+        file.write(text_formatted)
+
+
+    analysis = transcript_parser(file_dest, file_name)
+    print("\n Analysis: Shows Topics located in each chunk of the Document \n")
+    print(analysis)
+    print("\n Collapsed Analysis: Shows Unique topics located over the entire Document that meet the required confidence score. \n")
+    print(collapser(analysis))


### PR DESCRIPTION
One was designed for a long document, to extract topics and collapse them, leaving only unique results.  The youtube example takes a transcript from youtube api, then does the same topic extraction Both have a minimum confidence score setting, that can be used to remove non salient topics with low confidence scores, or alternatively to cast a wider net.