### PR TITLE
Remove deprecated import of `ModelFilter`

### DIFF
--- a/examples/Models/llmware_model_fast_start.py
+++ b/examples/Models/llmware_model_fast_start.py
@@ -18,7 +18,7 @@ import re
 import sys
 import time
 import torch
-from huggingface_hub import hf_api, ModelFilter, ModelCard
+from huggingface_hub import hf_api, ModelCard
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # The datasets package is not installed automatically by llmware


### PR DESCRIPTION
…lFilter`)

This PR remove deprecated import of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.