### PR TITLE
docs: Fix typos on certain pages of the LLMWare Docs Site

### DIFF
--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -58,7 +58,7 @@ Here is a non exhaustive list of contributions you can make.
 9. Improve documentation by adding or updating docstrings in modules, classes, methods, or functions (see for example [Add docstrings](https://github.com/llmware-ai/llmware/issues/219))
 10. Improve test coverage
 11. Answer questions in our [Discord channel](https://discord.gg/MhZn5Nc39h), especially in the [technical support forum](https://discord.com/channels/1179245642770559067/1218498778915672194)
-12. Post projects in which you use ``llmware`` in our Discord forum [made with llmware](https://discord.com/channels/1179245642770559067/1218567269471486012), ideially with a link to a public GitHub repository
+12. Post projects in which you use ``llmware`` in our Discord forum [made with llmware](https://discord.com/channels/1179245642770559067/1218567269471486012), ideally with a link to a public GitHub repository
 
 ## Open Issues
 If you're interested in existing issues, you can

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -14,7 +14,7 @@ permalink: /community/faq
 You can set the chunk size with the ``chunk_size`` parameter of the ``add_files`` method.
 
 The ``add_files`` method from the ``Library`` class has a ``chunk_size`` parameter that controls the chunk size.
-The method in addition has a parameter to control the maxium chunk size with ``max_chunk_size``.
+The method in addition has a parameter to control the maximum chunk size with ``max_chunk_size``.
 These two parameters are passed on to the ``Parser`` class.
 In the following example, we add the same files with different chunk sizes to the library ``chunk_size_example``.
 ```python
@@ -32,10 +32,10 @@ my_library.add_files(input_folder_path=path_to_my_library_files, chunk_size=600)
 
 ### How can I set the embedding store?
 #### "I want to use a specific embedding store"
-You can set the embedding store with the ``vector_db`` parameter of the ``install_new_embedding`` method, which you call on a ``Library`` object eacht time you want to create an embedding for a *library*.
+You can set the embedding store with the ``vector_db`` parameter of the ``install_new_embedding`` method, which you call on a ``Library`` object each time you want to create an embedding for a *library*.
 
 The ``install_new_embedding`` method from the ``Library`` class has a ``vector_db`` parameter that sets the embedding store.
-At the moment of this writting, *LLMWare* supports the embedding stores [chromadb](https://github.com/chroma-core/chroma), [neo4j](https://github.com/neo4j/neo4j), [milvus](https://github.com/milvus-io/milvus), [pg_vector](https://github.com/pgvector/pgvector), [postgres](https://github.com/postgres/postgres), [redis](https://github.com/redis/redis), [pinecone](https://www.pinecone.io/), [faiss](https://github.com/facebookresearch/faiss), [qdrant](https://github.com/qdrant/qdrant), [mongo atlas](https://www.mongodb.com/products/platform/atlas-database), and [lancedb](https://github.com/lancedb/lancedb).
+At the moment of this writing, *LLMWare* supports the embedding stores [chromadb](https://github.com/chroma-core/chroma), [neo4j](https://github.com/neo4j/neo4j), [milvus](https://github.com/milvus-io/milvus), [pg_vector](https://github.com/pgvector/pgvector), [postgres](https://github.com/postgres/postgres), [redis](https://github.com/redis/redis), [pinecone](https://www.pinecone.io/), [faiss](https://github.com/facebookresearch/faiss), [qdrant](https://github.com/qdrant/qdrant), [mongo atlas](https://www.mongodb.com/products/platform/atlas-database), and [lancedb](https://github.com/lancedb/lancedb).
 In the following example, we create the same embeddings three times for the same library, but store them in three different embedding stores.
 ```python
 import logging
@@ -60,9 +60,9 @@ library.install_new_embedding(vector_db="faiss")
 You can set the collection store with the ``set_active_db`` method of the ``LLMWareConfig`` class.
 
 The collection store is set using the ``LLMWareConfig`` class with the ``set_active_db`` method.
-At the time of writting, **LLMWare** supports the three collection stores *MongoDB*, *Postgres*, and *SQLite* - which is the default.
+At the time of writing, **LLMWare** supports the three collection stores *MongoDB*, *Postgres*, and *SQLite* - which is the default.
 You can retrieve the supported collection store with the method ``get_supported_collection_db``.
-In the example below, we first print the currently active collection store, then we retrieve the supported collection stores, before we swith to *Postgres*.
+In the example below, we first print the currently active collection store, then we retrieve the supported collection stores, before we switch to *Postgres*.
 
 ```python
 import logging
@@ -87,7 +87,7 @@ The ``Query`` class has the methods ``query``, ``text_query``, and ``semantic_qu
 On a side note, ``query`` is a wrapper function for ``text_query`` and ``semantic_query``.
 The value of ``result_count`` is passed on to the queried embedding store to control the number of retrieved results.
 For example, for *pgvector* ``result_count`` is passed on to the value after the ``LIMIT`` keyword.
-In the ``SQL`` example below, you can see the resulting ``SQL`` query of ``LLMWare`` if ``result_count=10``, the name of the collectoin being ``agreements``, and the query vector being ``[1, 2, 3]``.
+In the ``SQL`` example below, you can see the resulting ``SQL`` query of ``LLMWare`` if ``result_count=10``, the name of the collection being ``agreements``, and the query vector being ``[1, 2, 3]``.
 ```sql
 SELECT
     id,
@@ -126,7 +126,7 @@ You can set the Large Language Model (LLM) with the ``gen_model`` parameter of t
 
 The ``Prompt`` class has the method ``load_model`` with the ``gen_model`` parameter which sets the LLM.
 The ``gen_model`` parameter is passed on to the ``ModelCatalog`` class, which loads the LLM either from HuggingFace or from another source.
-The ``ModelCatalog`` allows you to **list all available models** with the method ``list_generative_mdoels``, or just the local models ``list_generative_local_models``, or just the open source models ``list_open_source_models``.
+The ``ModelCatalog`` allows you to **list all available models** with the method ``list_generative_models``, or just the local models ``list_generative_local_models``, or just the open source models ``list_open_source_models``.
 In the example below, we log all available LLMs, including the ones that are available locally and the open source ones, and also create the prompters.
 Each prompter uses a different LLM from our [BLING model series](https://llmware.ai/about), which you can also find on [HuggingFace](https://huggingface.co/collections/llmware/bling-models-6553c718f51185088be4c91a).
 
@@ -158,7 +158,7 @@ You can set the embedding model with the ``embedding_model_name`` parameter of t
 
 The ``Library`` class has the method ``install_new_embedding`` with the ``embedding_model_name`` parameter which sets the embedding model.
 The ``ModelCatalog`` allows you to **list all available embedding models** with the ``list_embedding_models`` method.
-In the following example, we list all available embedding models, and then we create a library with the name ``embedding_models_example``, which we embedd two times with embedding models ``'mini-lm-sber'`` and ``'industry-bert-contracts'``.
+In the following example, we list all available embedding models, and then we create a library with the name ``embedding_models_example``, which we embed two times with embedding models ``'mini-lm-sber'`` and ``'industry-bert-contracts'``.
 
 ```python
 import logging

--- a/docs/community/join_our_community.md
+++ b/docs/community/join_our_community.md
@@ -19,7 +19,7 @@ ___
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct

--- a/docs/community/need_help.md
+++ b/docs/community/need_help.md
@@ -19,7 +19,7 @@ ___
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct

--- a/docs/community/troubleshooting.md
+++ b/docs/community/troubleshooting.md
@@ -114,7 +114,7 @@ If you have any trouble, feel free to raise an Issue and we can provide you with
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct

--- a/docs/components/agent_inference_server.md
+++ b/docs/components/agent_inference_server.md
@@ -140,7 +140,7 @@ Reach out to us on [GitHub Discussions](https://github.com/llmware-ai/llmware/di
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct
@@ -150,7 +150,7 @@ We welcome everyone into the ``llmware`` community.
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
 The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
-[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in October 2022.
 
 ## License
 

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -83,7 +83,7 @@ Reach out to us on [GitHub Discussions](https://github.com/llmware-ai/llmware/di
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct
@@ -93,7 +93,7 @@ We welcome everyone into the ``llmware`` community.
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
 The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
-[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in October 2022.
 
 ## License
 

--- a/docs/components/components.md
+++ b/docs/components/components.md
@@ -111,7 +111,7 @@ Reach out to us on [GitHub Discussions](https://github.com/llmware-ai/llmware/di
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct
@@ -121,7 +121,7 @@ We welcome everyone into the ``llmware`` community.
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
 The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
-[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in October 2022.
 
 ## License
 

--- a/docs/components/data_stores.md
+++ b/docs/components/data_stores.md
@@ -49,7 +49,7 @@ Reach out to us on [GitHub Discussions](https://github.com/llmware-ai/llmware/di
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct
@@ -59,7 +59,7 @@ We welcome everyone into the ``llmware`` community.
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
 The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
-[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in October 2022.
 
 ## License
 

--- a/docs/components/embedding_models.md
+++ b/docs/components/embedding_models.md
@@ -91,7 +91,7 @@ Reach out to us on [GitHub Discussions](https://github.com/llmware-ai/llmware/di
 
 ## Contributing
 Please first discuss any change you want to make publicly, for example on GitHub via raising an [issue](https://github.com/llmware-ai/llmware/issues) or starting a [new discussion](https://github.com/llmware-ai/llmware/discussions).
-You can also write an email or start a discussion on our Discrod channel.
+You can also write an email or start a discussion on our Discord channel.
 Read more about becoming a contributor in the [GitHub repo](https://github.com/llmware-ai/llmware/blob/main/CONTRIBUTING.md).
 
 ## Code of conduct
@@ -101,7 +101,7 @@ We welcome everyone into the ``llmware`` community.
 ## ``llmware`` and [AI Bloks](https://www.aibloks.com/home)
 ``llmware`` is an open source project from [AI Bloks](https://www.aibloks.com/home) - the company behind ``llmware``.
 The company offers a Software as a Service (SaaS) Retrieval Augmented Generation (RAG) service.
-[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in Oktober 2022.
+[AI Bloks](https://www.aibloks.com/home) was founded by [Namee Oberst](https://www.linkedin.com/in/nameeoberst/) and [Darren Oberst](https://www.linkedin.com/in/darren-oberst-34a4b54/) in October 2022.
 
 ## License
 


### PR DESCRIPTION
### Description

This PR fixes typos on certain pages on the LLMWare Docs Site.

### Issues

N/A

- [x] This PR follows LLMWare Contributing Guidelines. 