### PR TITLE
feat && fix: added new models to modelCatalog, updated .gitignore to ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ docs/_site/
 
 # Mac
 .DS_Store/
+
+# Testing
+.env

--- a/llmware/model_configs.py
+++ b/llmware/model_configs.py
@@ -427,6 +427,14 @@ global_model_repo_catalog_list = [
     {"model_name": 'claude-2.0', "display_name": "Anthropic Claude-Claude2-.0",
     "model_family": "ClaudeModel", "model_category": "generative-api", "model_location": "api", "context_window": 8192},
 
+    {"model_name": 'claude-3-haiku-20240307', "display_name": "Anthropic Claude 3 Haiku", "model_family": "ClaudeModel", "model_category": "generative-api", "model_location": "api", "context_window": 200000},
+
+    {"model_name": 'claude-3-5-haiku-20241022', "display_name": "Anthropic Claude 3.5 Haiku", "model_family": "ClaudeModel", "model_category": "generative-api", "model_location": "api", "context_window": 200000},
+
+    {"model_name": 'claude-3-5-sonnet-20240620', "display_name": "Anthropic Claude 3.5 Sonnet", "model_family": "ClaudeModel", "model_category": "generative-api", "model_location": "api", "context_window": 200000},
+
+    {"model_name": 'claude-3-7-sonnet-20250219', "display_name": "Anthropic Claude 3.7 Sonnet", "model_family": "ClaudeModel", "model_category": "generative-api", "model_location": "api", "context_window": 200000},
+
     {"model_name": 'command-medium-nightly', "display_name": "Cohere Command Medium", "model_family": "CohereGenModel",
      "model_category": "generative-api","model_location": "api", "context_window": 2048},
 

--- a/llmware/models.py
+++ b/llmware/models.py
@@ -6033,7 +6033,7 @@ class ClaudeModel(BaseModel):
             # new Claude 3 models use the 'messages' API
             # please check that you have pip installed the latest anthropic python sdk
 
-            if self.model_name in ["claude-3-opus-20240229", "claude-3-sonnet-20240229"]:
+            if self.model_name in ["claude-3-opus-20240229", "claude-3-sonnet-20240229","claude-3-haiku-20240307", "claude-3-5-haiku-20241022", "claude-3-5-sonnet-20240620", "claude-3-7-sonnet-20250219"]:
 
                 # use messages API
                 message = client.messages.create(model=self.model_name, max_tokens=self.target_requested_output_tokens,


### PR DESCRIPTION
added the following claude models in the modelCatalog:

Claude 3 Haiku: A smaller, faster Claude 3 version introduced in March 2024. Lower latency for simpler tasks, accessible through Anthropic’s API.

Claude 3.5 Haiku: Released in October 2024. Matches most of Claude 3 Opus’s performance but keeps the speed of the earlier Haiku model.

Claude 3.5 Sonnet: An enhanced Claude 3 Sonnet, also from October 2024, with notable improvements in coding and tool use.

Claude 3.7 Sonnet: Released February 2025, supports up to a 200k token context and features advanced hybrid reasoning. Outperforms previous 3.x Claude models.


All these models are driven by message API