### PR TITLE
Fix: File Permissions Allow Too Many People Access in examples/SLIM-Agents/agent-multistep-analysis.py

### DIFF
--- a/examples/SLIM-Agents/agent-multistep-analysis.py
+++ b/examples/SLIM-Agents/agent-multistep-analysis.py
@@ -46,7 +46,7 @@ def multistep_analysis():
 
     if not os.path.exists(microsoft_folder):
         os.mkdir(microsoft_folder)
-        os.chmod(microsoft_folder, 0o777)
+        os.chmod(microsoft_folder, 0o644)
         shutil.copy(path_to_bill_gates_bio,os.path.join(microsoft_folder, bill_gates_bio))
 
     #   create library


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** These permissions `0o777` are widely permissive and grant access to more people than may be necessary. A good default is `0o644` which gives read and write access to yourself and read access to everyone else.
- **Rule ID:** python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
- **Severity:** MEDIUM
- **File:** examples/SLIM-Agents/agent-multistep-analysis.py
- **Lines Affected:** 49 - 49

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `examples/SLIM-Agents/agent-multistep-analysis.py` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.