### PR TITLE
Fix delete_installed_embedding to reset embedding to initial value

### DIFF
--- a/llmware/resources.py
+++ b/llmware/resources.py
@@ -502,6 +502,10 @@ class MongoWriter:
                 embedding_list.append(update_dict["embedding"])
                 embedding_update_dict = {"embedding": embedding_list}
             else:
+                if not inserted_list:
+                    inserted_list = [{"embedding_status": "no", "embedding_model": "none",
+                                      "embedding_db": "none", "embedded_blocks": 0,
+                                      "embedding_dims": 0, "time_stamp": "NA"}]
                 embedding_update_dict = {"embedding": inserted_list}
 
             self.collection.update_one(f, {"$set": embedding_update_dict})
@@ -1840,6 +1844,10 @@ class PGWriter:
 
             output = embedding_list
         else:
+            if not inserted_list:
+                inserted_list = [{"embedding_status": "no", "embedding_model": "none",
+                                  "embedding_db": "none", "embedded_blocks": 0,
+                                  "embedding_dims": 0, "time_stamp": "NA"}]
             output = inserted_list
 
         return output
@@ -2938,6 +2946,10 @@ class SQLiteWriter:
 
             output = embedding_list
         else:
+            if not inserted_list:
+                inserted_list = [{"embedding_status": "no", "embedding_model": "none",
+                                  "embedding_db": "none", "embedded_blocks": 0,
+                                  "embedding_dims": 0, "time_stamp": "NA"}]
             output = inserted_list
 
         return output

--- a/tests/library/test_embedding_delete.py
+++ b/tests/library/test_embedding_delete.py
@@ -1,0 +1,80 @@
+"""Tests for delete_installed_embedding resetting to initial value.
+
+Verifies fix for GitHub issue #1094:
+When deleting the last embedding, the embedding field should reset to the initial
+value rather than becoming an empty list.
+"""
+
+from llmware.resources import SQLiteWriter, PGWriter
+
+
+class TestEmbeddingRecordHandler:
+    """Test _update_embedding_record_handler behavior when deleting embeddings."""
+
+    def test_delete_last_embedding_resets_to_initial_value_sqlite(self):
+        """Test that SQLiteWriter resets embedding to initial value after deleting last embedding."""
+        initial_embedding = [{"embedding_status": "yes", "embedding_model": "test-model",
+                              "embedding_db": "chromadb", "embedded_blocks": 100,
+                              "embedding_dims": 384, "time_stamp": "test"}]
+
+        delete_value = {"embedding_status": "delete", "embedding_model": "test-model",
+                        "embedding_db": "chromadb", "embedded_blocks": 0,
+                        "embedding_dims": 384, "time_stamp": "NA"}
+
+        writer = SQLiteWriter.__new__(SQLiteWriter)
+        result = writer._update_embedding_record_handler(
+            initial_embedding.copy(), delete_value, delete_record=True
+        )
+
+        assert len(result) == 1
+        assert result[0]["embedding_status"] == "no"
+        assert result[0]["embedding_model"] == "none"
+        assert result[0]["embedding_db"] == "none"
+        assert result[0]["embedded_blocks"] == 0
+        assert result[0]["embedding_dims"] == 0
+
+    def test_delete_last_embedding_resets_to_initial_value_postgres(self):
+        """Test that PGWriter resets embedding to initial value after deleting last embedding."""
+        initial_embedding = [{"embedding_status": "yes", "embedding_model": "test-model",
+                              "embedding_db": "chromadb", "embedded_blocks": 100,
+                              "embedding_dims": 384, "time_stamp": "test"}]
+
+        delete_value = {"embedding_status": "delete", "embedding_model": "test-model",
+                        "embedding_db": "chromadb", "embedded_blocks": 0,
+                        "embedding_dims": 384, "time_stamp": "NA"}
+
+        writer = PGWriter.__new__(PGWriter)
+        result = writer._update_embedding_record_handler(
+            initial_embedding.copy(), delete_value, delete_record=True
+        )
+
+        assert len(result) == 1
+        assert result[0]["embedding_status"] == "no"
+        assert result[0]["embedding_model"] == "none"
+        assert result[0]["embedding_db"] == "none"
+        assert result[0]["embedded_blocks"] == 0
+        assert result[0]["embedding_dims"] == 0
+
+    def test_delete_one_of_multiple_embeddings_keeps_others(self):
+        """Test that deleting one embedding from multiple keeps the others."""
+        initial_embeddings = [
+            {"embedding_status": "yes", "embedding_model": "model-a",
+             "embedding_db": "chromadb", "embedded_blocks": 100,
+             "embedding_dims": 384, "time_stamp": "test1"},
+            {"embedding_status": "yes", "embedding_model": "model-b",
+             "embedding_db": "chromadb", "embedded_blocks": 200,
+             "embedding_dims": 768, "time_stamp": "test2"}
+        ]
+
+        delete_value = {"embedding_status": "delete", "embedding_model": "model-a",
+                        "embedding_db": "chromadb", "embedded_blocks": 0,
+                        "embedding_dims": 384, "time_stamp": "NA"}
+
+        writer = SQLiteWriter.__new__(SQLiteWriter)
+        result = writer._update_embedding_record_handler(
+            initial_embeddings.copy(), delete_value, delete_record=True
+        )
+
+        assert len(result) == 1
+        assert result[0]["embedding_model"] == "model-b"
+        assert result[0]["embedded_blocks"] == 200


### PR DESCRIPTION
## Summary
- Fixes embedding field being set to empty list `[]` instead of initial value when deleting last embedding
- Affects MongoWriter, PGWriter, and SQLiteWriter implementations
- Enables subsequent embedding operations to work correctly after deletion

## Test plan
- Added unit tests for `_update_embedding_record_handler` method
- Tests verify reset to initial value when deleting last embedding
- Tests verify keeping other embeddings when deleting one from multiple

Fixes #1094

Signed-off-by: majiayu000 <1835304752@qq.com>