### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/llmware/models.py
+++ b/llmware/models.py
@@ -96,6 +96,7 @@ class _ModelRegistry:
                      "ClaudeModel":{"module": "llmware.models", "open_source": False},
                      "GoogleGeminiModel":{"module": "llmware.models", "open_source": False},
                      "OpenAIEmbeddingModel":{"module": "llmware.models", "open_source": False},
+                     "LiteLLMModel":{"module": "llmware.models", "open_source": False},
                      }
 
     model_catalog_state_attributes = ["selected_model", "loaded_model_name", "loaded_model_class", "temperature",
@@ -7124,6 +7125,267 @@ class ClaudeModel(BaseModel):
         logger.debug(f"ClaudeModel - output_response - {output_response}")
 
         # output inference parameters
+        self.llm_response = text_out
+        self.usage = usage
+        self.logits = None
+        self.output_tokens = None
+        self.final_prompt = prompt_enriched
+
+        self.register()
+
+        return output_response
+
+
+class LiteLLMModel(BaseModel):
+
+    """ LiteLLMModel class implements the LiteLLM SDK for calling 100+ LLM providers
+    (Anthropic, Bedrock, Vertex AI, Cohere, Mistral, etc.) through a unified interface.
+    Users specify the provider via the model string, e.g. 'anthropic/claude-sonnet-4-5'. """
+
+    def __init__(self, model_name=None, api_key=None, context_window=32768,
+                 max_output=1000, temperature=0.0, **kwargs):
+
+        super().__init__(**kwargs)
+
+        self.model_class = "LiteLLMModel"
+        self.model_category = "generative"
+        self.llm_response = None
+        self.usage = None
+        self.logits = None
+        self.output_tokens = None
+        self.final_prompt = None
+
+        self.api_key = api_key
+        self.model_name = model_name
+
+        self.error_message = "\nUnable to connect to LiteLLM. Please try again later."
+
+        self.separator = "\n"
+
+        self.max_total_len = context_window
+        self.max_input_len = int(context_window * 0.5)
+        self.llm_max_output_len = int(context_window * 0.5)
+
+        if temperature >= 0.0:
+            self.temperature = temperature
+        else:
+            self.temperature = 0.0
+
+        self.target_requested_output_tokens = max_output
+        self.add_prompt_engineering = False
+        self.add_context = ""
+        self.prompt = ""
+        self.instruction_following = False
+        self.prompt_wrapper = None
+
+        if "model_card" in kwargs:
+            self.model_card = kwargs["model_card"]
+        else:
+            self.model_card = {}
+
+        self.post_init()
+
+    def set_api_key(self, api_key, env_var="USER_MANAGED_LLM_API_KEY"):
+
+        os.environ[env_var] = api_key
+        logger.info(f"LiteLLMModel - stored api_key in environmental variable- {env_var}")
+
+        return self
+
+    def _get_api_key(self, env_var="USER_MANAGED_LLM_API_KEY"):
+
+        self.api_key = os.environ.get(env_var)
+        return self.api_key
+
+    def token_counter(self, text_sample):
+
+        tokenizer = Utilities().get_default_tokenizer()
+        toks = tokenizer.encode(text_sample).ids
+        return len(toks)
+
+    def prompt_engineer(self, query, context, inference_dict=None):
+
+        self.instruction_following = False
+        self.prompt_wrapper = False
+
+        if not self.instruction_following:
+            if context:
+                output = context + "\n" + query
+            else:
+                output = query
+
+            if self.prompt_wrapper:
+                output = PromptCatalog().apply_prompt_wrapper(output, self.prompt_wrapper,
+                                                              instruction=None)
+            return output
+
+        if not self.add_prompt_engineering:
+            if context:
+                selected_prompt = "default_with_context"
+            else:
+                selected_prompt = "default_no_context"
+        else:
+            selected_prompt = self.add_prompt_engineering
+
+        prompt_dict = PromptCatalog().build_core_prompt(prompt_name=selected_prompt,
+                                                        separator=self.separator,
+                                                        query=query,
+                                                        context=context,
+                                                        inference_dict=inference_dict)
+
+        if prompt_dict:
+            prompt_engineered = prompt_dict["core_prompt"]
+        else:
+            prompt_engineered = "Please read the following text: " + context + self.separator
+            prompt_engineered += "Based on this text, please answer the question: " + query + self.separator
+            prompt_engineered += ("Please answer the question only with facts provided in the materials.  "
+                                 "If the question can not be answered in the materials, then please "
+                                 "respond 'Not Found.'")
+
+        if self.prompt_wrapper:
+            prompt_engineered = PromptCatalog().apply_prompt_wrapper(prompt_engineered, self.prompt_wrapper,
+                                                                     instruction=None)
+
+        return prompt_engineered
+
+    def inference(self, prompt, add_context=None, add_prompt_engineering=None, inference_dict=None,
+                  api_key=None):
+
+        self.prompt = prompt
+
+        if add_context:
+            self.add_context = add_context
+
+        if add_prompt_engineering:
+            self.add_prompt_engineering = add_prompt_engineering
+
+        if inference_dict:
+
+            if "temperature" in inference_dict:
+                self.temperature = inference_dict["temperature"]
+
+            if "max_tokens" in inference_dict:
+                self.target_requested_output_tokens = inference_dict["max_tokens"]
+
+        if api_key:
+            self.api_key = api_key
+
+        if not self.api_key:
+            self.api_key = self._get_api_key()
+
+        self.preview()
+
+        try:
+            import litellm
+        except ImportError:
+            raise DependencyNotInstalledException("litellm")
+
+        prompt_enriched = self.prompt_engineer(self.prompt, self.add_context, inference_dict=inference_dict)
+
+        time_start = time.time()
+
+        try:
+            response = litellm.completion(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt_enriched}],
+                temperature=self.temperature,
+                max_tokens=self.target_requested_output_tokens,
+                api_key=self.api_key if self.api_key else None,
+                drop_params=True,
+            )
+
+            text_out = response.choices[0].message.content
+
+            usage = {"input": response.usage.prompt_tokens,
+                     "output": response.usage.completion_tokens,
+                     "total": response.usage.total_tokens,
+                     "metric": "tokens",
+                     "processing_time": time.time() - time_start}
+
+        except Exception as e:
+            text_out = "/***ERROR***/"
+            usage = {"input": 0, "output": 0, "total": 0, "metric": "tokens",
+                     "processing_time": time.time() - time_start}
+
+            logger.error(f"LiteLLMModel - inference produced error - {e}")
+
+        output_response = {"llm_response": text_out, "usage": usage}
+
+        self.llm_response = text_out
+        self.usage = usage
+        self.logits = None
+        self.output_tokens = None
+        self.final_prompt = prompt_enriched
+
+        self.register()
+
+        return output_response
+
+    def stream(self, prompt, add_context=None, add_prompt_engineering=None, inference_dict=None,
+               api_key=None):
+
+        self.prompt = prompt
+
+        if add_context:
+            self.add_context = add_context
+
+        if add_prompt_engineering:
+            self.add_prompt_engineering = add_prompt_engineering
+
+        if inference_dict:
+
+            if "temperature" in inference_dict:
+                self.temperature = inference_dict["temperature"]
+
+            if "max_tokens" in inference_dict:
+                self.target_requested_output_tokens = inference_dict["max_tokens"]
+
+        if api_key:
+            self.api_key = api_key
+
+        if not self.api_key:
+            self.api_key = self._get_api_key()
+
+        self.preview()
+
+        try:
+            import litellm
+        except ImportError:
+            raise DependencyNotInstalledException("litellm")
+
+        prompt_enriched = self.prompt_engineer(self.prompt, self.add_context, inference_dict=inference_dict)
+
+        time_start = time.time()
+
+        try:
+            response = litellm.completion(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt_enriched}],
+                temperature=self.temperature,
+                max_tokens=self.target_requested_output_tokens,
+                api_key=self.api_key if self.api_key else None,
+                drop_params=True,
+                stream=True,
+            )
+
+            text_out = ""
+            for chunk in response:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    text_out += chunk.choices[0].delta.content
+                    yield chunk.choices[0].delta.content
+
+            usage = {"input": 0, "output": 0, "total": 0, "metric": "tokens",
+                     "processing_time": time.time() - time_start}
+
+        except Exception as e:
+            text_out = "/***ERROR***/"
+            usage = {"input": 0, "output": 0, "total": 0, "metric": "tokens",
+                     "processing_time": time.time() - time_start}
+
+            logger.error(f"LiteLLMModel - stream inference produced error - {e}")
+
+        output_response = {"llm_response": text_out, "usage": usage}
+
         self.llm_response = text_out
         self.usage = usage
         self.logits = None

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'redis': ['redis==5.0.1'],
         'mongo': ['pymongo>=4.7.0'],
         'neo4j': ['neo4j==5.16.0'],
+        'litellm': ['litellm>=1.55.0,<1.85'],
         'full': ['pymongo>=4.7.0', 'torch>=1.13.1', 'transformers>=4.36.0', 'einops>=0.7.0',
                  'Wikipedia-API>=0.6.0','openai>=1.0', 'datasets>=2.15.0', 'yfinance>=0.2.38', 'pymilvus<=2.5.1',
                  'chromadb>=0.4.22', 'streamlit', 'psycopg-binary==3.1.17', 'psycopg==3.1.17',


### PR DESCRIPTION
## Summary

- Adds LiteLLM as a new model class, giving users access to 100+ LLM providers (Anthropic, Bedrock, Vertex AI, Cohere, Mistral, etc.) through a single unified interface.
- Follows the existing model class pattern (mirrors `ClaudeModel`). Drop-in, no changes to existing providers.

## Motivation

llmware currently supports individual API providers (OpenAI, Claude, Google Gemini) each as separate model classes. LiteLLM is a lightweight Python SDK that provides a unified `completion()` interface across 100+ providers. Users specify the provider via the model string (e.g. `anthropic/claude-sonnet-4-5`, `bedrock/anthropic.claude-v2`, `vertex_ai/gemini-pro`) and LiteLLM routes the call to the correct provider API. This lets users access any LiteLLM-supported provider without needing a new model class for each one.

## Changes

- `llmware/models.py` - new `LiteLLMModel` class extending `BaseModel`, registered in `_ModelRegistry.model_classes`
- `setup.py` - added `litellm>=1.55.0,<1.85` as optional dependency (`pip install llmware[litellm]`)

## Implementation details

- **Optional dependency**: `litellm` is lazy-imported inside `inference()` and `stream()`, following the same pattern as `ClaudeModel` (which imports `anthropic` inside its methods). Users who don't install litellm are unaffected.
- **`drop_params=True`**: Silently drops provider-unsupported kwargs, preventing cross-provider failures.
- **Streaming**: `stream()` method implemented as a generator matching the `ClaudeModel.stream()` pattern.
- **Provider auth**: LiteLLM reads provider-specific env vars automatically (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.).
- **Prompt engineering**: Reuses the same `prompt_engineer()` pattern from `ClaudeModel`.
- **Token counting**: Uses the same GPT2 approximate tokenizer as other model classes.

## Example usage

```python
from llmware.models import LiteLLMModel
import os

# Set provider-specific API key
os.environ["ANTHROPIC_API_KEY"] = "sk-..."

# Create model instance
model = LiteLLMModel(model_name="anthropic/claude-sonnet-4-5", max_output=500)

# Run inference
response = model.inference("What is machine learning?")
print(response["llm_response"])

# Streaming
for chunk in model.stream("Explain RAG in 3 sentences."):
    print(chunk, end="", flush=True)
```

Or use via `ModelCatalog` by registering a model card:

```python
from llmware.models import ModelCatalog

ModelCatalog().register_new_model_card({
    "model_name": "my-litellm-claude",
    "model_family": "LiteLLMModel",
    "model_category": "generative-api",
    "display_name": "Claude via LiteLLM",
    "context_window": 200000,
})

model = ModelCatalog().load_model("my-litellm-claude")
response = model.inference("Hello world")
```

## Tests

**Live E2E test** against Anthropic Claude (`anthropic/claude-sonnet-4-5`):

```python
>>> m = LiteLLMModel(model_name='anthropic/claude-sonnet-4-5', max_output=200, temperature=0.0)
>>> m.inference('What is 2+2? Answer with just the number.')
{'llm_response': '4', 'usage': {'input': 20, 'output': 5, 'total': 25, 'metric': 'tokens', 'processing_time': 4.27}}

>>> for chunk in m.stream('What is the capital of France? Answer in one word.'):
...     print(chunk, end='')
Paris
```

## Risk / Compatibility

- Additive only. Existing model classes untouched.
- `litellm` is an optional extra. Base install unaffected.
- Pinned to `>=1.55.0,<1.85` for stability.
