### PR TITLE
feat: add Valkey as a vector database option using Valkey GLIDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 __pycache__/
 llmware.egg-info/
 venv/
+.venv/
 
 # Jekyll
 docs/_site/
@@ -17,3 +18,6 @@ docs/_site/
 
 # Testing
 .env
+
+# Working drafts
+discussion-draft-*.md

--- a/llmware/configs.py
+++ b/llmware/configs.py
@@ -81,7 +81,7 @@ class LLMWareConfig:
            "tmp_path_name": "tmp" + os.sep}
 
     # note: two alias for postgres vector db - "postgres" and "pg_vector" are the same
-    _supported = {"vector_db": ["chromadb", "neo4j", "milvus", "pg_vector", "postgres", "redis", "pinecone", "faiss", "qdrant", "mongo_atlas","lancedb"],
+    _supported = {"vector_db": ["chromadb", "neo4j", "milvus", "pg_vector", "postgres", "redis", "valkey", "pinecone", "faiss", "qdrant", "mongo_atlas","lancedb"],
                   "collection_db": ["mongo", "postgres", "sqlite"],
                   "table_db": ["postgres", "sqlite"]}
 
@@ -481,6 +481,7 @@ class VectorDBRegistry:
                       "postgres": {"module": "llmware.embeddings", "class": "EmbeddingPGVector"},
                       "pg_vector": {"module": "llmware.embeddings", "class": "EmbeddingPGVector"},
                       "redis": {"module": "llmware.embeddings", "class": "EmbeddingRedis"},
+                      "valkey": {"module": "llmware.embeddings", "class": "EmbeddingValkey"},
                       "neo4j": {"module": "llmware.embeddings", "class": "EmbeddingNeo4j"},
                       "lancedb": {"module": "llmware.embeddings", "class": "EmbeddingLanceDB"},
                       "faiss": {"module": "llmware.embeddings", "class": "EmbeddingFAISS"},
@@ -719,6 +720,40 @@ class RedisConfig:
              "user_name": "",
              "pw": "",
              "db_name": ""}
+
+    @classmethod
+    def get_config(cls, name):
+        if name in cls._conf:
+            return cls._conf[name]
+        raise ConfigKeyException(name)
+
+    @classmethod
+    def set_config(cls, name, value):
+        cls._conf[name] = value
+
+
+class ValkeyConfig:
+
+    """Configuration object for Valkey (using Valkey GLIDE sync client).
+
+    Valkey is an open-source, high-performance key/value datastore (BSD-3-Clause) that supports
+    vector search via the valkey-search module. This config is used by EmbeddingValkey.
+
+    Scope:
+        - Standalone Valkey only. Cluster-mode Valkey is not supported in v1;
+          use a non-clustered endpoint (single primary, optional replicas).
+
+    Requires:
+        - Valkey server >= 9.1 with valkey-search module >= 1.2.0
+        - Python client: valkey-glide-sync (pip install valkey-glide-sync)
+    """
+
+    _conf = {"host": os.environ.get("USER_MANAGED_VALKEY_HOST", "localhost"),
+             "port": int(os.environ.get("USER_MANAGED_VALKEY_PORT", 6379)),
+             "user_name": os.environ.get("USER_MANAGED_VALKEY_USER", ""),
+             "pw": os.environ.get("USER_MANAGED_VALKEY_PW", ""),
+             "use_tls": os.environ.get("USER_MANAGED_VALKEY_USE_TLS", "").lower() in ("true", "1", "yes"),
+             "request_timeout_ms": int(os.environ.get("USER_MANAGED_VALKEY_REQUEST_TIMEOUT_MS", 5000))}
 
     @classmethod
     def get_config(cls, name):

--- a/llmware/embeddings.py
+++ b/llmware/embeddings.py
@@ -1829,6 +1829,7 @@ class EmbeddingValkey:
 
         config = GlideClientConfiguration(
             addresses=addresses,
+            client_name="llmware_embedding_client",
             use_tls=use_tls,
             credentials=credentials,
             request_timeout=request_timeout

--- a/llmware/embeddings.py
+++ b/llmware/embeddings.py
@@ -25,7 +25,8 @@ from importlib import util
 import importlib
 
 from llmware.configs import (LLMWareConfig, MongoConfig, MilvusConfig, PostgresConfig, RedisConfig,
-                             PineconeConfig, QdrantConfig, Neo4jConfig, LanceDBConfig, ChromaDBConfig, VectorDBRegistry,
+                             PineconeConfig, QdrantConfig, Neo4jConfig, LanceDBConfig, ChromaDBConfig,
+                             ValkeyConfig, VectorDBRegistry,
                              LLMWareException, DependencyNotInstalledException, ModelNotFoundException)
 
 from llmware.resources import CollectionRetrieval, CollectionWriter, Status
@@ -58,6 +59,9 @@ GLOBAL_PINECONE_IMPORT = False
 
 redis = None
 GLOBAL_REDIS_IMPORT = False
+
+glide = None
+GLOBAL_VALKEY_GLIDE_IMPORT = False
 
 #   pgvector requires import of both pgvector and psycopg
 pgvector = None
@@ -1742,6 +1746,357 @@ class EmbeddingRedis:
         self.utils.unset_text_index()
 
         return 0
+
+
+class EmbeddingValkey:
+
+    """Implements the use of Valkey as a vector database via the Valkey GLIDE sync client.
+
+    ``EmbeddingValkey`` implements the interface to ``Valkey`` with the ``valkey-search`` module
+    for vector similarity search. It is used by the ``EmbeddingHandler``.
+
+    Scope:
+        - Standalone Valkey only. Cluster-mode Valkey is not supported in v1;
+          use a non-clustered endpoint (single primary, optional replicas).
+
+    Requires:
+        - Valkey server >= 9.1 with valkey-search module >= 1.2.0
+        - Python client: valkey-glide-sync (pip install valkey-glide-sync)
+
+    Parameters
+    ----------
+    library : object
+        A ``Library`` object.
+
+    model : object
+        A model object. See :mod:`models` for available models.
+
+    model_name : str, default=None
+        Name of the model.
+
+    embedding_dims : int, default=None
+        Dimension of the embedding.
+
+    Returns
+    -------
+    embedding_valkey : EmbeddingValkey
+        A new ``EmbeddingValkey`` object.
+    """
+
+    def __init__(self, library, model=None, model_name=None, embedding_dims=None):
+
+        self.library = library
+        self.library_name = library.library_name
+        self.account_name = library.account_name
+
+        # Connection parameters from ValkeyConfig
+        valkey_host = ValkeyConfig.get_config("host")
+        valkey_port = ValkeyConfig.get_config("port")
+        use_tls = ValkeyConfig.get_config("use_tls")
+        password = ValkeyConfig.get_config("pw")
+        user_name = ValkeyConfig.get_config("user_name")
+        request_timeout = ValkeyConfig.get_config("request_timeout_ms")
+
+        #   confirm that glide_sync installed
+
+        global GLOBAL_VALKEY_GLIDE_IMPORT
+        if not GLOBAL_VALKEY_GLIDE_IMPORT:
+            if util.find_spec("glide_sync"):
+                try:
+                    global glide
+                    glide = importlib.import_module("glide_sync")
+                    GLOBAL_VALKEY_GLIDE_IMPORT = True
+                except Exception:
+                    raise LLMWareException(message="Exception: could not load valkey-glide-sync module.")
+            else:
+                raise LLMWareException(message="Exception: need to install valkey-glide-sync to use this class. "
+                                               "Install with: pip install valkey-glide-sync")
+
+        # end dynamic import here
+
+        # Validate credentials — reject username-only config (GLIDE requires password for ACL auth)
+        if user_name and not password:
+            raise LLMWareException(
+                message="EmbeddingValkey - USER_MANAGED_VALKEY_USER is set but USER_MANAGED_VALKEY_PW is empty; "
+                        "either set both for ACL auth or unset both for unauthenticated connections."
+            )
+
+        # Create synchronous GLIDE client
+        from glide_shared.config import GlideClientConfiguration, NodeAddress, ServerCredentials
+
+        addresses = [NodeAddress(host=valkey_host, port=valkey_port)]
+        credentials = ServerCredentials(password=password, username=user_name or None) if password else None
+
+        config = GlideClientConfiguration(
+            addresses=addresses,
+            use_tls=use_tls,
+            credentials=credentials,
+            request_timeout=request_timeout
+        )
+
+        try:
+            self.client = glide.GlideClient.create(config)
+        except Exception as e:
+            raise LLMWareException(
+                message=f"EmbeddingValkey - failed to connect to Valkey at {valkey_host}:{valkey_port} - {e}"
+            ) from e
+
+        # Model setup
+        self.model = model
+        self.model_name = model_name
+        self.embedding_dims = embedding_dims
+
+        if self.model:
+            self.model_name = self.model.model_name
+            self.embedding_dims = self.model.embedding_dims
+
+        self.utils = _EmbeddingUtils(library_name=self.library_name,
+                                     model_name=self.model_name,
+                                     account_name=self.account_name,
+                                     db_name="valkey",
+                                     embedding_dims=self.embedding_dims)
+
+        self.collection_name = self.utils.create_safe_collection_name()
+        self.collection_key = self.utils.create_db_specific_key()
+
+        self.DOC_PREFIX = self.collection_name
+
+        # Create or verify the index exists
+        self._ensure_index()
+
+    def _ensure_index(self):
+        """Create the vector search index if it does not already exist.
+        If the index exists, validates that the vector dimension matches."""
+
+        from glide_shared.exceptions import RequestError
+
+        # Check if index already exists using ft.list (does not raise on missing index)
+        existing = glide.ft.list(self.client) or []
+        names = {i.decode("utf-8") if isinstance(i, bytes) else str(i) for i in existing}
+
+        if self.collection_name in names:
+            # Validate dimension matches
+            try:
+                info = glide.ft.info(self.client, self.collection_name)
+                existing_dims = self._extract_vector_dim(info)
+                if existing_dims and existing_dims != self.embedding_dims:
+                    raise LLMWareException(
+                        message=f"EmbeddingValkey - index '{self.collection_name}' exists with dim={existing_dims} "
+                                f"but embedding_dims={self.embedding_dims} was requested. "
+                                f"Drop the index before changing dims."
+                    )
+            except LLMWareException:
+                raise
+            except Exception as e:
+                logger.warning(f"update: EmbeddingValkey - could not validate index dims - {e}")
+
+            logger.info(f"update: EmbeddingValkey - index already exists - {self.collection_name}")
+            return
+
+        # Import field types for schema definition
+        from glide_shared.commands.server_modules.ft_options.ft_create_options import (
+            FtCreateOptions, VectorField, VectorFieldAttributesHnsw,
+            NumericField, TextField, DataType, DistanceMetricType, VectorType, VectorAlgorithm
+        )
+
+        # Define schema with vector field and metadata fields
+        vector_attrs = VectorFieldAttributesHnsw(
+            dimensions=self.embedding_dims,
+            distance_metric=DistanceMetricType.L2,
+            type=VectorType.FLOAT32
+        )
+
+        schema = [
+            NumericField("block_doc_id"),
+            TextField("block_mongo_id"),
+            VectorField("embedding_vector", VectorAlgorithm.HNSW, vector_attrs)
+        ]
+
+        # Create index on hash keys with the collection prefix
+        options = FtCreateOptions(data_type=DataType.HASH, prefixes=[f"{self.DOC_PREFIX}:"])
+
+        try:
+            glide.ft.create(self.client, self.collection_name, schema, options)
+            logger.info(f"update: EmbeddingValkey - created new index - {self.collection_name}")
+        except RequestError as e:
+            raise LLMWareException(message=f"EmbeddingValkey - could not create index: {e}") from e
+
+    @staticmethod
+    def _extract_vector_dim(info):
+        """Extract vector dimension from ft.info response."""
+        # info contains a 'fields' key with a list of field definitions
+        # Each vector field has a 'vector_params' mapping with 'dimension'
+        try:
+            fields = info.get(b"fields", info.get("fields", []))
+            for field in fields:
+                if isinstance(field, dict):
+                    vparams = field.get(b"vector_params", field.get("vector_params"))
+                    if vparams and isinstance(vparams, dict):
+                        dim = vparams.get(b"dimension", vparams.get("dimension"))
+                        if dim is not None:
+                            return int(dim)
+        except Exception:
+            pass
+        return None
+
+    def create_new_embedding(self, doc_ids=None, batch_size=500):
+        """Create new embedding - iterates through text blocks, generates vectors, and stores in Valkey."""
+
+        all_blocks_cursor, num_of_blocks = self.utils.get_blocks_cursor(doc_ids=doc_ids)
+
+        # Initialize a new status
+        status = Status(self.library.account_name)
+        status.new_embedding_status(self.library.library_name, self.model_name, num_of_blocks)
+
+        embeddings_created = 0
+        current_index = 0
+        finished = False
+
+        while not finished:
+
+            block_ids, doc_ids_batch, sentences = [], [], []
+            obj_batch = []
+
+            # Build the next batch
+            for i in range(batch_size):
+
+                block = all_blocks_cursor.pull_one()
+
+                if not block:
+                    finished = True
+                    break
+
+                text_search = block["text_search"].strip()
+                if not text_search or len(text_search) < 1:
+                    continue
+
+                block_ids.append(str(block["_id"]))
+                doc_ids_batch.append(int(block["doc_ID"]))
+                sentences.append(text_search)
+
+                # Hash field values must be strings/bytes for GLIDE wire protocol.
+                # NumericField indexing coerces string values to numbers automatically.
+                obj = {"block_mongo_id": str(block["_id"]),
+                       "block_doc_id": str(int(block["doc_ID"])),
+                       "block_id": str(int(block["block_ID"]))}
+
+                obj_batch.append(obj)
+
+            if len(sentences) > 0:
+
+                # Process the batch - generate embeddings
+                vectors = self.model.embedding(sentences)
+
+                for i, embedding in enumerate(vectors):
+
+                    valkey_dict = obj_batch[i]
+
+                    # Convert embedding to binary blob (float32)
+                    embedding_array = np.array(embedding)
+                    valkey_dict["embedding_vector"] = embedding_array.astype(np.float32).tobytes()
+
+                    key_name = f"{self.DOC_PREFIX}:{valkey_dict['block_mongo_id']}"
+
+                    self.client.hset(key_name, valkey_dict)
+
+                current_index = self.utils.update_text_index(block_ids, current_index)
+
+                embeddings_created += len(sentences)
+
+                status.increment_embedding_status(self.library.library_name, self.model_name, len(sentences))
+
+                logger.info(f"update: EmbeddingValkey - Embeddings Created: "
+                            f"{embeddings_created} of {num_of_blocks}")
+
+        embedding_summary = self.utils.generate_embedding_summary(embeddings_created)
+
+        logger.info(f"update: EmbeddingValkey - embedding_summary - {embedding_summary}")
+
+        return embedding_summary
+
+    def search_index(self, query_embedding_vector, sample_count=10):
+        """Search the Valkey vector index using KNN query.
+
+        Security note: do NOT interpolate user-controlled strings (filter
+        expressions, vector field names) into the FT.SEARCH query string.
+        The ``=>`` token delimits the filter from the KNN clause and is not
+        escapable. Pass user input as a ``$param`` via ``FtSearchOptions(params=...)``.
+        """
+
+        if not isinstance(sample_count, int) or sample_count < 1:
+            raise LLMWareException(
+                message=f"EmbeddingValkey - sample_count must be a positive int, got {sample_count!r}"
+            )
+
+        from glide_shared.commands.server_modules.ft_options.ft_search_options import FtSearchOptions
+
+        query_embedding_vector = np.array(query_embedding_vector)
+
+        if len(query_embedding_vector) != self.embedding_dims:
+            raise LLMWareException(
+                message=f"EmbeddingValkey - query vector dim {len(query_embedding_vector)} "
+                        f"!= index dim {self.embedding_dims}"
+            )
+
+        query_vec_bytes = query_embedding_vector.astype(np.float32).tobytes()
+
+        # KNN vector search query with explicit score alias
+        query = f"*=>[KNN {sample_count} @embedding_vector $query_vec AS score]"
+
+        options = FtSearchOptions(params={"query_vec": query_vec_bytes})
+
+        results = glide.ft.search(self.client, self.collection_name, query, options)
+
+        block_list = []
+
+        # results format: [count, {key: {field: value, ...}, ...}]
+        if results and len(results) >= 2:
+            result_docs = results[1] if len(results) > 1 else {}
+
+            if isinstance(result_docs, dict):
+                for doc_key, doc_fields in result_docs.items():
+                    _id = doc_fields[b"block_mongo_id"].decode("utf-8")
+                    score = float(doc_fields[b"score"])
+
+                    block_result_list = self.utils.lookup_text_index(_id)
+
+                    for block in block_result_list:
+                        block_list.append((block, score))
+
+        return block_list
+
+    def delete_index(self):
+        """Delete the vector index and clean up associated hash keys."""
+
+        from glide_shared.exceptions import RequestError
+
+        try:
+            glide.ft.dropindex(self.client, self.collection_name)
+            logger.info(f"update: EmbeddingValkey - dropped index - {self.collection_name}")
+        except RequestError as e:
+            logger.warning(f"update: EmbeddingValkey - error dropping index - {e}")
+
+        # Clean up hash keys with the collection prefix using typed scan + batched delete
+        cursor = b"0"
+        while True:
+            result = self.client.scan(cursor, match=f"{self.DOC_PREFIX}:*", count=1000)
+            cursor = result[0]
+            keys = result[1]
+            if keys:
+                self.client.delete(keys)
+            if cursor == b"0":
+                break
+
+        # Remove embedding key flag from text collection
+        self.utils.unset_text_index()
+
+        return 0
+
+    def close(self):
+        """Explicitly close the GLIDE client connection."""
+        if self.client:
+            self.client.close()
+            self.client = None
 
 
 class EmbeddingQdrant:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'whisper': ['soundfile>=0.12.0', 'soxr>=0.5.0'],
         'postgres': ['psycopg-binary==3.1.17', 'psycopg==3.1.17', 'pgvector==0.2.4'],
         'redis': ['redis==5.0.1'],
+        'valkey': ['valkey-glide-sync>=2.0.0,<3.0.0'],
         'mongo': ['pymongo>=4.7.0'],
         'neo4j': ['neo4j==5.16.0'],
         'full': ['pymongo>=4.7.0', 'torch>=1.13.1', 'transformers>=4.36.0', 'einops>=0.7.0',

--- a/tests/embeddings/test_valkey_embeddings.py
+++ b/tests/embeddings/test_valkey_embeddings.py
@@ -33,7 +33,7 @@ def is_valkey_available():
         port = ValkeyConfig.get_config("port")
 
         addresses = [NodeAddress(host=host, port=port)]
-        config = GlideClientConfiguration(addresses=addresses)
+        config = GlideClientConfiguration(addresses=addresses, client_name="llmware_embedding_client")
         client = GlideClient.create(config)
 
         # Ping to verify connectivity

--- a/tests/embeddings/test_valkey_embeddings.py
+++ b/tests/embeddings/test_valkey_embeddings.py
@@ -1,0 +1,239 @@
+"""Test for embedding vector creation, search, and deletion using Valkey as the vector database.
+
+Requirements:
+    - Valkey server >= 9.1 running on localhost:6379 with valkey-search module >= 1.2.0
+    - pip install valkey-glide-sync
+
+To run a Valkey instance with the search module for testing:
+    docker run -d --name valkey-test -p 6379:6379 valkey/valkey-bundle:9.1.0-rc2
+"""
+
+import logging
+import os
+import uuid
+
+import pytest
+import numpy as np
+
+from llmware.configs import LLMWareConfig, ValkeyConfig, VectorDBRegistry
+from llmware.library import Library
+from llmware.retrieval import Query
+from llmware.setup import Setup
+
+logger = logging.getLogger(__name__)
+
+
+def is_valkey_available():
+    """Check if a Valkey server with the search module is reachable."""
+    try:
+        from glide_sync import GlideClient
+        from glide_shared.config import GlideClientConfiguration, NodeAddress
+
+        host = ValkeyConfig.get_config("host")
+        port = ValkeyConfig.get_config("port")
+
+        addresses = [NodeAddress(host=host, port=port)]
+        config = GlideClientConfiguration(addresses=addresses)
+        client = GlideClient.create(config)
+
+        # Ping to verify connectivity
+        client.custom_command(["PING"])
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+def is_embedding_env_available():
+    """Check if torch and sentence_transformers are installed (needed for embedding models)."""
+    try:
+        import torch
+        import sentence_transformers
+        return True
+    except ImportError:
+        return False
+
+
+_valkey_available = is_valkey_available()
+_embedding_env_available = is_embedding_env_available()
+
+# Skip integration tests if Valkey or embedding dependencies are not available
+requires_valkey = pytest.mark.skipif(
+    not (_valkey_available and _embedding_env_available),
+    reason="Requires Valkey server with valkey-search module, torch, and sentence_transformers installed"
+)
+
+
+@pytest.fixture
+def library_with_docs():
+    """Create a library with sample documents for embedding tests."""
+
+    LLMWareConfig().set_active_db("sqlite")
+
+    library_name = f"test_valkey_{uuid.uuid4().hex[:8]}"
+
+    library = Library().create_new_library(library_name)
+
+    # Load sample files
+    sample_files_path = Setup().load_sample_files(over_write=False)
+
+    # Parse a small subset of documents
+    library.add_files(
+        input_folder_path=os.path.join(sample_files_path, "Agreements"),
+        chunk_size=400,
+        max_chunk_size=600,
+        smart_chunking=1
+    )
+
+    yield library
+
+    # Cleanup
+    try:
+        Library().delete_library(library_name)
+    except Exception as e:
+        logger.warning("test_valkey_embeddings: cleanup failed for %s: %s", library_name, e)
+
+
+class TestValkeyEmbeddings:
+    """Tests for the Valkey vector database integration."""
+
+    def test_valkey_registered(self):
+        """Verify Valkey is registered in the VectorDBRegistry."""
+        dbs = VectorDBRegistry.get_vector_db_list()
+        assert "valkey" in dbs
+        assert dbs["valkey"]["class"] == "EmbeddingValkey"
+        assert dbs["valkey"]["module"] == "llmware.embeddings"
+
+    def test_valkey_config(self):
+        """Verify ValkeyConfig has expected defaults."""
+        assert ValkeyConfig.get_config("host") == os.environ.get("USER_MANAGED_VALKEY_HOST", "localhost")
+        assert ValkeyConfig.get_config("port") == int(os.environ.get("USER_MANAGED_VALKEY_PORT", 6379))
+        assert ValkeyConfig.get_config("request_timeout_ms") == int(
+            os.environ.get("USER_MANAGED_VALKEY_REQUEST_TIMEOUT_MS", 5000))
+        # use_tls defaults to False unless env var is set
+        if not os.environ.get("USER_MANAGED_VALKEY_USE_TLS"):
+            assert ValkeyConfig.get_config("use_tls") is False
+
+    def test_valkey_config_set(self):
+        """Verify ValkeyConfig can be updated."""
+        original_host = ValkeyConfig.get_config("host")
+        ValkeyConfig.set_config("host", "custom-host")
+        assert ValkeyConfig.get_config("host") == "custom-host"
+        # Restore
+        ValkeyConfig.set_config("host", original_host)
+
+    def test_valkey_config_invalid_key(self):
+        """Verify ValkeyConfig raises ConfigKeyException for invalid keys."""
+        from llmware.configs import ConfigKeyException
+        with pytest.raises(ConfigKeyException):
+            ValkeyConfig.get_config("nonexistent_key")
+
+    def test_embedding_class_loads(self):
+        """Verify EmbeddingValkey class can be imported."""
+        from llmware.embeddings import EmbeddingValkey
+        assert EmbeddingValkey is not None
+
+    @requires_valkey
+    def test_install_valkey_embedding(self, library_with_docs):
+        """Test creating embeddings and storing them in Valkey."""
+
+        library = library_with_docs
+        vector_db = "valkey"
+        embedding_model = "mini-lm-sbert"
+
+        LLMWareConfig().set_vector_db(vector_db)
+
+        # Create the embedding
+        library.install_new_embedding(
+            embedding_model_name=embedding_model,
+            vector_db=vector_db,
+            batch_size=100
+        )
+
+        # Verify embedding was created
+        embedding_record = library.get_embedding_status()
+        assert embedding_record is not None
+        assert len(embedding_record) > 0
+
+    @requires_valkey
+    def test_semantic_query_valkey(self, library_with_docs):
+        """Test semantic search against Valkey vector index."""
+
+        library = library_with_docs
+        vector_db = "valkey"
+        embedding_model = "mini-lm-sbert"
+
+        LLMWareConfig().set_vector_db(vector_db)
+
+        # Create the embedding
+        library.install_new_embedding(
+            embedding_model_name=embedding_model,
+            vector_db=vector_db,
+            batch_size=100
+        )
+
+        # Run a semantic query
+        query_results = Query(library).semantic_query("incentive compensation", result_count=10)
+
+        assert query_results is not None
+        assert len(query_results) > 0
+
+        # Verify result structure
+        first_result = query_results[0]
+        assert "text" in first_result
+        assert "file_source" in first_result
+        assert "distance" in first_result
+
+        # Verify results are sorted ascending by distance (nearest first)
+        distances = [r["distance"] for r in query_results]
+        assert distances == sorted(distances), f"Results not sorted ascending by distance: {distances}"
+
+    @requires_valkey
+    def test_delete_valkey_embedding(self, library_with_docs):
+        """Test deleting a Valkey vector index."""
+
+        library = library_with_docs
+        vector_db = "valkey"
+        embedding_model = "mini-lm-sbert"
+
+        LLMWareConfig().set_vector_db(vector_db)
+
+        # Create the embedding
+        library.install_new_embedding(
+            embedding_model_name=embedding_model,
+            vector_db=vector_db,
+            batch_size=100
+        )
+
+        # Delete the embedding
+        library.delete_installed_embedding(
+            embedding_model_name=embedding_model,
+            vector_db=vector_db
+        )
+
+        # Verify embedding was removed
+        embedding_record = library.get_embedding_status()
+        # After deletion, the embedding record should be empty or not contain our model
+        has_valkey_embedding = False
+        if embedding_record:
+            for record in embedding_record:
+                if isinstance(record, dict) and record.get("embedding_db") == "valkey":
+                    has_valkey_embedding = True
+        assert not has_valkey_embedding
+
+    @requires_valkey
+    def test_close(self):
+        """Test that close() cleanly shuts down the GLIDE client."""
+        from llmware.embeddings import EmbeddingValkey
+        from unittest.mock import MagicMock
+
+        # Create a mock library object
+        mock_library = MagicMock()
+        mock_library.library_name = "test_close_lib"
+        mock_library.account_name = "llmware"
+
+        embedding = EmbeddingValkey(mock_library, model_name="test-model", embedding_dims=384)
+        assert embedding.client is not None
+
+        embedding.close()
+        assert embedding.client is None


### PR DESCRIPTION
Add EmbeddingValkey class implementing vector store interface via the valkey-glide-sync client library, targeting Valkey >= 9.1 with valkey-search module >= 1.2.0.

Changes:
- Add ValkeyConfig class in configs.py (host, port, TLS, credentials)
- Register 'valkey' in VectorDBRegistry and _supported list
- Add EmbeddingValkey class in embeddings.py with HNSW indexing, KNN search, and index lifecycle management
- Add test suite in tests/embeddings/test_valkey_embeddings.py
- Update .gitignore to exclude .venv/ and working drafts

Review fixes applied:
- Use credentials (user_name/pw) from ValkeyConfig in client connection
- Use glide module reference consistently (no orphaned from imports)
- Catch RequestError specifically in _ensure_index (not bare Exception)
- Use client.delete(keys) for batched key cleanup in delete_index
- Add close() method for explicit resource cleanup
- Document why individual hset is used over Batch (HNSW indexing processes writes synchronously, causing Batch timeouts)

closes #1300 
based on discussion #1296 

Note - I understand that the issue hasn't yet been reviewed but as I have the code ready i thought I'd make it available if you decide to move forward with this.