### PR TITLE
fix(util): add missing comma between "never" and "nevertheless" stop words

### DIFF
--- a/llmware/util.py
+++ b/llmware/util.py
@@ -499,7 +499,7 @@ class Utilities:
                       "meantime" ,"meanwhile" ,"merely" ,"mg" ,"might","miss", "ml" ,"more" ,"moreover",
                       "most" ,"mostly" ,"mr" ,"mr." ,"mrs" ,"mrs." ,"ms", "ms." ,"much" ,"mug","must" ,"my" ,"myself",
                       "n" ,"na" ,"name" ,"namely" ,"nay" ,"nd" ,"near" ,"nearly" ,"necessarily" ,"necessary" ,"need"
-                      ,"needs", "neither" ,"never""nevertheless" ,"new" ,"next" ,"nine" ,"ninety" ,"no" ,"nobody",
+                      ,"needs", "neither" ,"never" ,"nevertheless" ,"new" ,"next" ,"nine" ,"ninety" ,"no" ,"nobody",
                       "non" ,"none","nonetheless","noone" ,"nor" ,"normally" ,"nos" ,"not" ,"note" ,"noted" ,
                       "nothing" ,"now" ,"nowhere" ,"o" ,"obtain","obtained", "obviously" ,"of" ,"off" ,"often",
                       "oh" ,"ok" ,"okay" ,"old" ,"omit" ,"omitted" ,"on" ,"once" ,"one","ones","only" ,"onto" ,"or",


### PR DESCRIPTION
## Problem

In `Utilities.get_stop_words_master_list()` (`llmware/util.py`, line 502) two adjacent stop-word entries are missing the comma between them:

```python
,"needs", "neither" ,"never""nevertheless" ,"new" ,"next" , ...
```

`"never""nevertheless"` is Python **implicit string-literal concatenation** → it compiles to the single token `"nevernevertheless"`. Every other one of the ~750 entries in the list is comma-separated; this is the only adjacency. Consequences:

- `"never"` is **not** in the returned list.
- `"nevertheless"` is **not** in the returned list.
- a junk token `"nevernevertheless"` **is** in the list and can never match a real word.

## Impact

`get_stop_words_master_list()` feeds `remove_stop_words()` / `prune_stop_words()` / `CorpTokenizer`, used in the tokenization and context-pruning paths across `prompts.py`, `retrieval.py`, `models.py`, and `agents.py`. So `"never"` and `"nevertheless"` (canonical English stop words) are treated as meaningful tokens during search-relevance tokenization and context reduction instead of being filtered.

## Reproduction

```python
from llmware.util import Utilities
s = Utilities.get_stop_words_master_list()
```

| | before | after |
|---|---|---|
| `"never" in s` | `False` ❌ | `True` |
| `"nevertheless" in s` | `False` ❌ | `True` |
| `"nevernevertheless" in s` | `True` ❌ | `False` |

## Fix

Insert the missing comma:

```python
,"needs", "neither" ,"never" ,"nevertheless" ,"new" ,"next" , ...
```

Verified against the real function (list now contains both words and no longer the merged token); `python -m py_compile llmware/util.py` passes.
