### PR TITLE
fix(resources): bind collection filter values as SQL parameters (#1304)

### DIFF
--- a/llmware/resources.py
+++ b/llmware/resources.py
@@ -1185,24 +1185,28 @@ class PGRetrieval:
                     f"FROM {self.library_name} " \
                     f"WHERE ts @@ to_tsquery('english', {search_string})"
 
+        #   filter values are bound as query parameters - never interpolated into the SQL string
+        insert_array = ()
+
         if key_value_dict:
             for key, value in key_value_dict.items():
 
                 if isinstance(value,list):
 
-                    # need to check this
-                    value_range = str(value)
-                    value_range = value_range.replace("[", "(")
-                    value_range = value_range.replace("]", ")")
-
-                    sql_query += f" AND {key} IN {value_range}"
+                    sql_query += f" AND {key} IN %s"
+                    insert_array += (tuple(value),)
                 else:
-                    sql_query += f" AND {key} = '{value}'"
+                    sql_query += f" AND {key} = %s"
+                    insert_array += (value,)
 
         sql_query += " ORDER BY rank"
         sql_query += ";"
 
-        results = self.conn.cursor().execute(sql_query)
+        if insert_array:
+            results = self.conn.cursor().execute(sql_query, insert_array)
+        else:
+            results = self.conn.cursor().execute(sql_query)
+
         output_results = self.unpack_search_result(results)
 
         self.conn.close()
@@ -1233,6 +1237,10 @@ class PGRetrieval:
         sql_query = f"SELECT * FROM {self.library_name}"
 
         conditions_clause = " WHERE"
+
+        #   filter values are bound as query parameters - never interpolated into the SQL string
+        insert_array = ()
+
         for key, value in key_dict.items():
 
             #   handles passing a filter with 'mongo' style $in key range
@@ -1243,23 +1251,22 @@ class PGRetrieval:
                     logger.debug(f"update: Postgres - filter_by_key_dict - value - {value}")
 
                     if isinstance(value,list):
-                        v_str = "("
-                        for entry in value:
-                            v_str += str(entry) + ","
-                        if v_str.endswith(","):
-                            v_str = v_str[:-1]
-                        v_str += ")"
-                        conditions_clause += f" {key} IN {v_str} AND "
+                        conditions_clause += f" {key} IN %s AND "
+                        insert_array += (tuple(value),)
             else:
 
-                conditions_clause += f" {key} = '{value}' AND "
+                conditions_clause += f" {key} = %s AND "
+                insert_array += (value,)
 
         if conditions_clause.endswith(' AND '):
             conditions_clause = conditions_clause[:-5]
         if len(conditions_clause) > len(" WHERE"):
             sql_query += conditions_clause + ";"
 
-        results = self.conn.cursor().execute(sql_query)
+        if insert_array:
+            results = self.conn.cursor().execute(sql_query, insert_array)
+        else:
+            results = self.conn.cursor().execute(sql_query)
 
         output = self.unpack(results)
 
@@ -2256,6 +2263,7 @@ class SQLiteRetrieval:
 
         sql_query = f"SELECT rank, rowid, * FROM {self.library_name} WHERE text_search MATCH '{query_str}' "
 
+        #   filter values are bound as query parameters - never interpolated into the SQL string
         insert_array = ()
 
         if key_value_dict:
@@ -2266,20 +2274,16 @@ class SQLiteRetrieval:
                     sql_query += f" AND ("
 
                     for items in value:
-                        if isinstance(value,str):
-                            sql_query += f" {key} = '{items}' OR "
-                        else:
-                            sql_query += f" {key} = {items} OR "
+                        sql_query += f" {key} = ? OR "
+                        insert_array += (items,)
 
                     if sql_query.endswith("OR "):
                         sql_query = sql_query[:-3]
                     sql_query += ")"
 
                 else:
-                    if isinstance(value,str):
-                        sql_query += f" AND {key} = '{value}'"
-                    else:
-                        sql_query += f" AND {key} = {value}"
+                    sql_query += f" AND {key} = ?"
+                    insert_array += (value,)
 
         sql_query += " ORDER BY rank"
         sql_query += ";"
@@ -2315,6 +2319,10 @@ class SQLiteRetrieval:
         sql_query = f"SELECT rowid, * FROM {self.library_name}"
 
         conditions_clause = " WHERE"
+
+        #   filter values are bound as query parameters - never interpolated into the SQL string
+        insert_array = ()
+
         for key, value in key_dict.items():
 
             #   handles passing a filter with 'mongo' style $in key range
@@ -2325,20 +2333,12 @@ class SQLiteRetrieval:
                     logger.debug(f"update: SQLite - filter_by_key_dict - value - {value}")
 
                     if isinstance(value,list):
-                        v_str = "("
-                        for entry in value:
-                            v_str += str(entry) + ","
-                        if v_str.endswith(","):
-                            v_str = v_str[:-1]
-                        v_str += ")"
-                        conditions_clause += f" {key} IN {v_str} AND "
+                        placeholders = ",".join(["?"] * len(value))
+                        conditions_clause += f" {key} IN ({placeholders}) AND "
+                        insert_array += tuple(value)
             else:
-                if isinstance(value, int):
-                    conditions_clause += f" {key} = {value} AND "
-                else:
-                    conditions_clause += f" {key} = '{value}' AND "
-
-            # conditions_clause += f" {key} = {value} AND "
+                conditions_clause += f" {key} = ? AND "
+                insert_array += (value,)
 
         if conditions_clause.endswith(" AND "):
             conditions_clause = conditions_clause[:-5]
@@ -2346,7 +2346,7 @@ class SQLiteRetrieval:
         if len(conditions_clause) > len(" WHERE"):
             sql_query += conditions_clause + ";"
 
-        results = self.conn.cursor().execute(sql_query)
+        results = self.conn.cursor().execute(sql_query, insert_array)
 
         output = self.unpack(results)
 


### PR DESCRIPTION
Fixes #1304.

## Problem

`llmware/resources.py` builds the `WHERE` clause of the SQLite and Postgres collection backends by interpolating the *filter value* directly into the SQL string:

```python
# SQLiteRetrieval.filter_by_key_dict
conditions_clause += f" {key} = '{value}' AND "
# PGRetrieval.filter_by_key_dict
conditions_clause += f" {key} = '{value}' AND "
```

The `key` is validated against the library's allowed-key list (`retrieval.py`) and the table name goes through `safe_name()`, but the value is never escaped or parameterized. A value containing a quote closes the literal and rewrites the predicate.

These sinks are reachable from the public API — `Library.block_lookup()` / `Query.document_lookup()` to `filter_by_key_dict`, and `Query.text_query_with_custom_filter()` / `text_query_by_author_or_speaker()` to `text_search_with_key_value_dict_filter` — where the values come from end-user query input or document metadata.

Reproduced against the SQLite `filter_by_key_dict` logic, with two rows belonging to different "tenants" and the filter `{"author_or_speaker": "alice' OR '1'='1"}`:

```
benign  old: [(1, 1, 1, 'alice', 'tenant-A public note')]
inject  old: [(1, 1, 1, 'alice', 'tenant-A public note'),
              (2, 2, 1, 'bob',   'tenant-B SECRET salary data')]   <-- filter neutralized
```

## Fix

Bind the values as query parameters in the four value sinks named in the issue:

* `PGRetrieval.text_search_with_key_value_dict_filter`
* `PGRetrieval.filter_by_key_dict`
* `SQLiteRetrieval.text_search_with_key_value_dict_filter`
* `SQLiteRetrieval.filter_by_key_dict`

Postgres uses `%s` placeholders and SQLite uses `?`, matching the parameter style already used elsewhere in this module (e.g. `PGRetrieval.embedding_job_cursor`, and `SQLiteRetrieval.text_search_with_key_value_dict_filter` which already carried an unused `insert_array = ()`). On Postgres the parameter tuple is only passed when it is non-empty, so a filter-less query still goes through the same single-argument `execute()` path as before and no `%` in the tsquery string gets reinterpreted.

The mongo-style `{"$in": [...]}` ranges are bound too. That also fixes a latent bug in those branches: list members were emitted through `str(entry)` with no quoting, so a list of strings produced `IN (alice,bob)` and raised `sqlite3.OperationalError: no such column: alice`. With placeholders it returns the expected rows.

After the change, same repro:

```
benign  new: [(1, 1, 1, 'alice', 'tenant-A public note')]
inject  new: []
$in str new: [(1, ... 'alice', ...), (2, ... 'bob', ...)]
```

Scope is limited to the value sinks reported in #1304 — key/table-name handling and the `_prep_query` full-text search string are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
